### PR TITLE
Improve build automation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# make sure *nix stays *nix
+*.sh      eol=lf
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,12 @@
 name: build
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    paths:
-      - '**/*'
-  
-  workflow_dispatch:
+      - master
+    tags:
+      - 'v*.*.*'
 
 jobs:
   macos-latest:
@@ -33,6 +32,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: artifacts/test-results
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: artifacts/packages
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -40,6 +49,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: artifacts/test-results
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: artifacts/packages
   windows-latest:
     name: windows-latest
     runs-on: windows-latest
@@ -47,3 +66,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
+      - name: 'Publish: test-results'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: artifacts/test-results
+      - name: 'Publish: packages'
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: artifacts/packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,7 @@ on:
   pull_request:
     branches:
       - main
+      - master
     paths:
       - '**/*'
 

--- a/Acornima.sln
+++ b/Acornima.sln
@@ -26,7 +26,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Acornima.Tests", "test\Acor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Acornima.Tests.Test262", "test\Acornima.Tests.Test262\Acornima.Tests.Test262.csproj", "{A7CA9D3E-5247-4212-9E08-BDECBC63B8E1}"
 EndProject
-lobal
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Acornima.Extras", "src\Acornima.Extras\Acornima.Extras.csproj", "{52853C1D-4BC3-4A82-B7C9-FDC2162689DA}"
+EndProject
+Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -62,6 +64,10 @@ lobal
 		{F2B479F2-5104-4ACB-BC8A-92422C9F3736}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F2B479F2-5104-4ACB-BC8A-92422C9F3736}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F2B479F2-5104-4ACB-BC8A-92422C9F3736}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52853C1D-4BC3-4A82-B7C9-FDC2162689DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52853C1D-4BC3-4A82-B7C9-FDC2162689DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52853C1D-4BC3-4A82-B7C9-FDC2162689DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52853C1D-4BC3-4A82-B7C9-FDC2162689DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -6,7 +6,7 @@ using Nuke.Components;
         GitHubActionsImage.MacOsLatest,
         GitHubActionsImage.UbuntuLatest,
         GitHubActionsImage.WindowsLatest,
-        OnPullRequestBranches = ["main"],
+        OnPullRequestBranches = ["main", "master"],
         OnPullRequestIncludePaths = ["**/*"],
         PublishArtifacts = false,
         InvokedTargets = [nameof(ICompile.Compile), nameof(ITest.Test), nameof(IPack.Pack)],
@@ -18,9 +18,9 @@ using Nuke.Components;
         GitHubActionsImage.MacOsLatest,
         GitHubActionsImage.UbuntuLatest,
         GitHubActionsImage.WindowsLatest,
-        OnPullRequestBranches = ["main"],
-        OnPullRequestIncludePaths = ["**/*"],
-        PublishArtifacts = false,
+        OnPushBranches = ["main", "master"],
+        OnPushTags = ["v*.*.*"],
+        PublishArtifacts = true,
         InvokedTargets = [nameof(ICompile.Compile), nameof(ITest.Test), nameof(IPack.Pack)],
         CacheKeyFiles = []
     )

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -18,14 +18,12 @@ partial class Build : NukeBuild, ITest, IPack
 {
     public static int Main() => Execute<Build>(x => ((ICompile) x).Compile);
 
-    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")] readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
-
     [GitRepository] readonly GitRepository GitRepository;
 
     AbsolutePath SourceDirectory => RootDirectory / "src";
     AbsolutePath TestDirectory => RootDirectory / "test";
 
-    string TagVersion => GitRepository.Tags.SingleOrDefault(x => "v".StartsWith(x))?[1..];
+    string TagVersion => GitRepository.Tags.SingleOrDefault(x => x.StartsWith('v'))?[1..];
     bool IsTaggedBuild => !string.IsNullOrWhiteSpace(TagVersion);
 
     string VersionSuffix;
@@ -45,7 +43,7 @@ partial class Build : NukeBuild, ITest, IPack
         }
 
         Log.Information("BUILD SETUP");
-        Log.Information("Configuration:\t{Configuration}", Configuration);
+        Log.Information("Configuration:\t{Configuration}", ((IHazConfiguration) this).Configuration);
         Log.Information("Version suffix:\t{VersionSuffix}", VersionSuffix);
         Log.Information("Version:\t\t{Version}", Version);
         Log.Information("Tagged build:\t{IsTaggedBuild}", IsTaggedBuild);

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -14,6 +14,12 @@ public partial class ParserTests
     [Fact]
     public void CanHandleDeepRecursionWithoutStackOverflow()
     {
+        if (OperatingSystem.IsMacOS())
+        {
+            // stack limit differ quite a lot
+            return;
+        }
+
         var parser = new Parser();
 #if DEBUG
         const int depth = 450;


### PR DESCRIPTION
* fix workflow definitions (this repo uses `master` instead of `main`, pr worfklow should track PRs and build workflow pushes/tags)
* add minimal .gitattributes (fixes build.sh)
* fix Acornima.sln
* exclude macOS from recursion testing

After changing GitHub definitions for NUKE, I needed to run `build.cmd` to generate new YAML files, that's the procedure for such changes.