### PR TITLE
Convenience API for dealing with variable scopes

### DIFF
--- a/samples/Acornima.Cli/Commands/PrintScopesCommand.cs
+++ b/samples/Acornima.Cli/Commands/PrintScopesCommand.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using System.Xml.Linq;
+using Acornima.Ast;
+using Acornima.Cli.Helpers;
+using Acornima.Jsx;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace Acornima.Cli.Commands;
+
+
+[Command(CommandName, Description = "Parse JS code and print tree of variable scopes.")]
+internal sealed class PrintScopesCommand
+{
+    public const string CommandName = "scopes";
+
+    private readonly IConsole _console;
+
+    public PrintScopesCommand(IConsole console)
+    {
+        _console = console;
+    }
+
+    [Option("--type", Description = "Type of the JS code to parse.")]
+    public JavaScriptCodeType CodeType { get; set; }
+
+    [Option("--jsx", Description = "Allow JSX expressions.")]
+    public bool AllowJsx { get; set; }
+
+    [Argument(0, Description = "The JS code to parse. If omitted, the code will be read from the standard input.")]
+    public string? Code { get; }
+
+    private T CreateParserOptions<T>() where T : ParserOptions, new() => new T().RecordScopeInfoInUserData();
+
+    public int OnExecute()
+    {
+        Console.InputEncoding = System.Text.Encoding.UTF8;
+
+        var code = Code ?? _console.ReadString();
+
+        IParser parser = AllowJsx
+            ? new JsxParser(CreateParserOptions<JsxParserOptions>())
+            : new Parser(CreateParserOptions<ParserOptions>());
+
+        Node rootNode = CodeType switch
+        {
+            JavaScriptCodeType.Script => parser.ParseScript(code),
+            JavaScriptCodeType.Module => parser.ParseModule(code),
+            JavaScriptCodeType.Expression => parser.ParseExpression(code),
+            _ => throw new InvalidOperationException()
+        };
+
+        var treePrinter = new TreePrinter(_console);
+        treePrinter.Print(new[] { rootNode },
+            node => node
+                .DescendantNodes(descendIntoChildren: descendantNode => ReferenceEquals(node, descendantNode) || descendantNode.UserData is not ScopeInfo)
+                .Where(node => node.UserData is ScopeInfo),
+            node =>
+            {
+                var scopeInfo = (ScopeInfo)node.UserData!;
+                var names = scopeInfo.VarVariables.Select(id => id.Name)
+                    .Concat(scopeInfo.LexicalVariables.Select(id => id.Name))
+                    .Concat(scopeInfo.Functions.Select(id => id.Name))
+                    .Distinct()
+                    .OrderBy(name => name);
+                return $"{node.TypeText} ({string.Join(", ", names)})";
+            });
+
+        return 0;
+    }
+}

--- a/src/Acornima.Extras/ParserOptionsExtensions.cs
+++ b/src/Acornima.Extras/ParserOptionsExtensions.cs
@@ -1,4 +1,6 @@
+using System;
 using Acornima.Ast;
+using Acornima.Helpers;
 
 namespace Acornima;
 
@@ -20,10 +22,37 @@ public static class ParserOptionsExtensions
         return options;
     }
 
+    public static TOptions RecordScopeInfoInUserData<TOptions>(this TOptions options, bool enable = true)
+        where TOptions : ParserOptions
+    {
+        var helper = options._onNode?.Target as OnNodeHelper;
+        if (enable)
+        {
+            (helper ?? new OnNodeHelper()).EnableScopeInfoRecoding(options);
+        }
+        else
+        {
+            helper?.DisableScopeInfoRecoding(options);
+        }
+
+        return options;
+    }
+
     private sealed class OnNodeHelper : IOnNodeHandlerWrapper
     {
         private OnNodeHandler? _onNode;
         public OnNodeHandler? OnNode { get => _onNode; set => _onNode = value; }
+
+        private ArrayList<ScopeInfo> _scopes;
+
+        public void ReleaseLargeBuffers()
+        {
+            _scopes.Clear();
+            if (_scopes.Capacity > 64)
+            {
+                _scopes.Capacity = 64;
+            }
+        }
 
         public void EnableParentNodeRecoding(ParserOptions options)
         {
@@ -32,11 +61,44 @@ public static class ParserOptionsExtensions
                 _onNode = options._onNode;
                 options._onNode = SetParentNode;
             }
+            else if (options._onNode == SetScopeInfo)
+            {
+                options._onNode = SetParentNodeAndScopeInfo;
+            }
         }
 
         public void DisableParentNodeRecoding(ParserOptions options)
         {
-            if (options._onNode == SetParentNode)
+            if (options._onNode == SetParentNodeAndScopeInfo)
+            {
+                options._onNode = SetScopeInfo;
+            }
+            else if (options._onNode == SetParentNode)
+            {
+                options._onNode = _onNode;
+            }
+        }
+
+        public void EnableScopeInfoRecoding(ParserOptions options)
+        {
+            if (!ReferenceEquals(options._onNode?.Target, this))
+            {
+                _onNode = options._onNode;
+                options._onNode = SetScopeInfo;
+            }
+            else if (options._onNode == SetParentNode)
+            {
+                options._onNode = SetParentNodeAndScopeInfo;
+            }
+        }
+
+        public void DisableScopeInfoRecoding(ParserOptions options)
+        {
+            if (options._onNode == SetParentNodeAndScopeInfo)
+            {
+                options._onNode = SetParentNode;
+            }
+            else if (options._onNode == SetScopeInfo)
             {
                 options._onNode = _onNode;
             }
@@ -50,6 +112,114 @@ public static class ParserOptionsExtensions
             }
 
             _onNode?.Invoke(node, context);
+        }
+
+        private void SetScopeInfo(Node node, OnNodeContext context)
+        {
+            if (context.HasScope)
+            {
+                SetScopeInfoCore(node, context._scope.Value, context.ScopeStack);
+            }
+
+            _onNode?.Invoke(node, context);
+        }
+
+        private void SetParentNodeAndScopeInfo(Node node, OnNodeContext context)
+        {
+            if (context.HasScope)
+            {
+                SetScopeInfoCore(node, context._scope.Value, context.ScopeStack);
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                if (child.UserData is ScopeInfo scopeInfo)
+                {
+                    scopeInfo.UserData = node;
+                }
+                else
+                {
+                    child.UserData = node;
+                }
+            }
+
+            _onNode?.Invoke(node, context);
+        }
+
+        private void SetScopeInfoCore(Node node, in Scope scope, ReadOnlySpan<Scope> scopeStack)
+        {
+            for (var n = scope.Id - _scopes.Count; n >= 0; n--)
+            {
+                ref var scopeInfoRef = ref _scopes.PushRef();
+                scopeInfoRef ??= new ScopeInfo();
+            }
+
+            var scopeInfo = _scopes.GetItemRef(scope.Id);
+            ref readonly var parentScope = ref scopeStack.Last();
+            var parentScopeInfo = scope.Id != scopeStack[0].Id ? _scopes[parentScope.Id] : null;
+
+            var varVariables = scope.VarVariables;
+            var lexicalVariables = scope.LexicalVariables;
+            Identifier? additionalLexicalVariable = null;
+
+            // In the case of function and catch clause scopes, we need to create a separate scope for parameters,
+            // otherwise variables declared in the body would be "visible" to the parameter nodes.
+
+            switch (node.Type)
+            {
+                case NodeType.CatchClause:
+                    var catchClause = node.As<CatchClause>();
+
+                    node.UserData = parentScopeInfo = new ScopeInfo().Initialize(
+                       node,
+                       parent: parentScopeInfo,
+                       varScope: _scopes[scopeStack[scope.CurrentVarScopeIndex].Id],
+                       thisScope: _scopes[scopeStack[scope.CurrentThisScopeIndex].Id],
+                       varVariables,
+                       lexicalVariables: lexicalVariables.Slice(0, scope.LexicalParamCount),
+                       functions: default);
+
+                    node = catchClause.Body;
+                    lexicalVariables = lexicalVariables.Slice(scope.LexicalParamCount);
+                    break;
+
+                case NodeType.ArrowFunctionExpression or NodeType.FunctionDeclaration or NodeType.FunctionExpression:
+                    var function = node.As<IFunction>();
+                    var functionBody = function.Body as FunctionBody;
+
+                    node.UserData = parentScopeInfo = (functionBody is not null ? new ScopeInfo() : scopeInfo).Initialize(
+                        node,
+                        parent: parentScopeInfo,
+                        varScope: _scopes[scopeStack[parentScope.CurrentVarScopeIndex].Id],
+                        thisScope: _scopes[scopeStack[parentScope.CurrentThisScopeIndex].Id],
+                        varVariables: varVariables.Slice(0, scope.VarParamCount),
+                        lexicalVariables: default,
+                        functions: default,
+                        additionalVarVariable: function.Id);
+
+                    if (functionBody is null)
+                    {
+                        return;
+                    }
+
+                    node = functionBody;
+                    varVariables = varVariables.Slice(scope.VarParamCount);
+                    break;
+
+                case NodeType.ClassDeclaration or NodeType.ClassExpression:
+                    additionalLexicalVariable = node.As<IClass>()?.Id;
+                    break;
+            }
+
+            node.UserData = scopeInfo.Initialize(
+                node,
+                parent: parentScopeInfo,
+                varScope: scope.CurrentVarScopeIndex == scopeStack.Length ? scopeInfo : _scopes[scopeStack[scope.CurrentVarScopeIndex].Id],
+                thisScope: scope.CurrentThisScopeIndex == scopeStack.Length ? scopeInfo : _scopes[scopeStack[scope.CurrentThisScopeIndex].Id],
+                varVariables,
+                lexicalVariables,
+                functions: scope.Functions,
+                additionalLexicalVariable: additionalLexicalVariable);
         }
     }
 }

--- a/src/Acornima.Extras/ScopeInfo.cs
+++ b/src/Acornima.Extras/ScopeInfo.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Runtime.CompilerServices;
+using Acornima.Ast;
+
+namespace Acornima;
+
+public sealed class ScopeInfo
+{
+    public static ScopeInfo From(Node associatedNode,
+        ScopeInfo? parent, ScopeInfo? varScope, ScopeInfo? thisScope,
+        ReadOnlySpan<Identifier> varVariables, ReadOnlySpan<Identifier> lexicalVariables, ReadOnlySpan<Identifier> functions)
+    {
+        var scope = new ScopeInfo();
+        return scope.Initialize(associatedNode ?? throw new ArgumentNullException(nameof(associatedNode)),
+            parent, varScope ?? scope, thisScope ?? scope,
+            varVariables, lexicalVariables, functions);
+    }
+
+    internal ScopeInfo()
+    {
+        AssociatedNode = null!;
+        VarScope = ThisScope = this;
+    }
+
+    internal ScopeInfo Initialize(Node associatedNode, ScopeInfo? parent, ScopeInfo varScope, ScopeInfo thisScope,
+        ReadOnlySpan<Identifier> varVariables, ReadOnlySpan<Identifier> lexicalVariables, ReadOnlySpan<Identifier> functions,
+        Identifier? additionalVarVariable = null, Identifier? additionalLexicalVariable = null)
+    {
+        AssociatedNode = associatedNode;
+        Parent = parent;
+        VarScope = varScope;
+        ThisScope = thisScope;
+        VarVariables = new VariableCollection(varVariables, additionalVarVariable);
+        LexicalVariables = new VariableCollection(lexicalVariables, additionalLexicalVariable);
+        Functions = new VariableCollection(functions, additionalItem: null);
+
+        return this;
+    }
+
+    public Node AssociatedNode { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+
+    public ScopeInfo? Parent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+    public ScopeInfo VarScope { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+    public ScopeInfo ThisScope { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+
+    /// <summary>
+    /// A list of distinct var-declared names sorted in ascending order in the current lexical scope.
+    /// </summary>
+    public VariableCollection VarVariables { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+
+    /// <summary>
+    ///  A list of distinct lexically-declared names sorted in ascending order in the current lexical scope.
+    /// </summary>
+    public VariableCollection LexicalVariables { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+
+    /// <summary>
+    /// A list of distinct lexically-declared <see cref="FunctionDeclaration"/> names sorted in ascending order in the current lexical scope.
+    /// </summary>
+    public VariableCollection Functions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; private set; }
+
+    /// <summary>
+    /// Gets or sets the arbitrary, user-defined data object associated with the current <see cref="ScopeInfo"/>.
+    /// </summary>
+    /// <remarks>
+    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
+    /// </remarks>
+    public object? UserData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set;
+    }
+}

--- a/src/Acornima.Extras/VariableCollection.cs
+++ b/src/Acornima.Extras/VariableCollection.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Acornima.Ast;
+
+namespace Acornima;
+
+[DebuggerDisplay($"{nameof(Count)} = {{{nameof(Count)}}}")]
+[DebuggerTypeProxy(typeof(DebugView))]
+public readonly struct VariableCollection : IReadOnlyCollection<Identifier>
+{
+    private readonly Identifier[]? _items;
+
+    internal VariableCollection(ReadOnlySpan<Identifier> items, Identifier? additionalItem)
+    {
+        if (additionalItem is not null)
+        {
+            if (items.Length == 0)
+            {
+                _items = new[] { additionalItem };
+                return;
+            }
+            _items = new Identifier[items.Length + 1];
+            _items[0] = additionalItem;
+            items.CopyTo(_items.AsSpan(1));
+        }
+        else
+        {
+            if (items.Length == 0)
+            {
+                return;
+            }
+            _items = items.ToArray();
+        }
+
+        Array.Sort(_items, NameComparer.Instance);
+    }
+
+    public VariableCollection(ReadOnlySpan<Identifier> items)
+        : this(items, additionalItem: null) { }
+
+    public VariableCollection(IEnumerable<Identifier> items)
+    {
+        _items = items.ToArray();
+        Array.Sort(_items, NameComparer.Instance);
+    }
+
+    public int Count { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _items?.Length ?? 0; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Contains(Identifier item)
+    {
+        return _items is not null && Array.IndexOf(_items, item) >= 0;
+    }
+
+    public bool Contains(string name)
+    {
+        for (int lo = 0, hi = Count - 1; lo <= hi;)
+        {
+            var i = lo + ((hi - lo) >> 1);
+            var order = string.CompareOrdinal(_items![i].Name, name);
+            if (order < 0)
+            {
+                lo = i + 1;
+            }
+            else if (order > 0)
+            {
+                hi = i - 1;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Enumerator GetEnumerator() => new Enumerator(this);
+
+    IEnumerator<Identifier> IEnumerable<Identifier>.GetEnumerator() => GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public struct Enumerator : IEnumerator<Identifier>
+    {
+        private readonly Identifier[]? _items;
+        private readonly int _count;
+        private int _index;
+
+        internal Enumerator(VariableCollection list)
+        {
+            _items = list._items;
+            _count = _items?.Length ?? 0;
+            _index = -1;
+        }
+
+        public readonly void Dispose() { }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            var index = _index + 1;
+            if (index < _count)
+            {
+                _index = index;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Reset()
+        {
+            _index = -1;
+        }
+
+        /// <remarks>
+        /// According to the <see href="https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.ienumerator-1.current#remarks">specification</see>,
+        /// accessing <see cref="Current"/> before calling <see cref="MoveNext"/> or after <see cref="MoveNext"/> returning <see langword="false"/> is undefined behavior.
+        /// Thus, to maximize performance, this implementation doesn't do any null or range checks, just let the default exceptions occur on invalid access.
+        /// </remarks>
+        public readonly Identifier Current { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _items![_index]; }
+
+        readonly object? IEnumerator.Current => Current;
+    }
+
+    private sealed class NameComparer : IComparer<Identifier>
+    {
+        public static readonly NameComparer Instance = new();
+
+        private NameComparer() { }
+
+        public int Compare(Identifier? x, Identifier? y) => string.CompareOrdinal(x!.Name, y!.Name);
+    }
+
+    [DebuggerNonUserCode]
+    private sealed class DebugView
+    {
+        private readonly VariableCollection _collection;
+
+        public DebugView(VariableCollection collection)
+        {
+            _collection = collection;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public Identifier[] Items => _collection.ToArray();
+    }
+}

--- a/src/Acornima/Parser.State.cs
+++ b/src/Acornima/Parser.State.cs
@@ -146,6 +146,8 @@ public partial class Parser
         }
 
         _tokenizer.ReleaseLargeBuffers();
+
+        (_options._onNode?.Target as IOnNodeHandlerWrapper)?.ReleaseLargeBuffers();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Acornima/ParserOptions.cs
+++ b/src/Acornima/ParserOptions.cs
@@ -18,6 +18,8 @@ public delegate void OnNodeHandler(Node node, OnNodeContext context);
 internal interface IOnNodeHandlerWrapper
 {
     OnNodeHandler? OnNode { get; set; }
+
+    void ReleaseLargeBuffers();
 }
 
 public record class ParserOptions


### PR DESCRIPTION
This PR is kind of an experiment to find out if exposing the variable scopes tracked by the parser for checking variable redeclarations makes sense in the first place, and if so, how it can be technically achieved and what the public API of such a feature should look like.

My goal with this is to provide a starting point to help us understand the problem better, explore our options so we can discuss them and shape the implementation and API accordingly.

The main requirement regarding the implementation is that it must not degrade the performance of the primary consumer (Jint execution engine) significantly. This applies to both execution time and memory allocation + the memory footprint of the resulting AST. Big changes to the parser's logic are not allowed either, as it should stay a close translation of acornjs.

Beyond that, the main goal, of course, is to come up with the most convenient API possible for the consumers. However, I don't intend to implement and maintain an "all batteries included" solution but a general one that provides access to the scope information (and maybe some convenience features in the Extras package) for consumers who want to deal with variable scopes. That is, a limited feature set is preferred, which leaves the possibility open for consumers to work with variable scopes in a way that is optimized to their specific use cases (I mean primarily the freedom to choose the data structure to store the scope tree.)

All ideas and feedback are welcome!