### PR TITLE
Convert to use Central Package Management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           dotnet-version: |
             6.0
+            8.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish

--- a/Acornima.sln
+++ b/Acornima.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
+		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C428FBAE-48E0-4C47-B9D2-688866714516}"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="DiffEngine" Version="15.5.3" />
+    <PackageVersion Include="Esprima" Version="3.0.5" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Nuke.Components" Version="8.1.4" />
+    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.49.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="Test262Harness" Version="1.0.1" />
+    <PackageVersion Include="UnicodeInformation" Version="2.7.1" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
+    <PackageVersion Include="Verify.XUnit" Version="28.1.3" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.analyzers" Version="1.17.0" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- global private assets -->
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="DiffEngine" Version="13.0.2" />
     <PackageVersion Include="Esprima" Version="3.0.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
@@ -13,18 +12,14 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Nuke.Components" Version="8.1.4" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Test262Harness" Version="1.0.1" />
     <PackageVersion Include="UnicodeInformation" Version="2.7.1" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.2.0" />
-    <PackageVersion Include="Verify.XUnit" Version="22.8.0" />
+    <PackageVersion Include="Verify.XUnit" Version="23.7.2" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.17.0" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="DiffEngine" Version="15.5.3" />
+    <PackageVersion Include="DiffEngine" Version="13.0.2" />
     <PackageVersion Include="Esprima" Version="3.0.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
@@ -23,9 +23,9 @@
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Test262Harness" Version="1.0.1" />
     <PackageVersion Include="UnicodeInformation" Version="2.7.1" />
-    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
-    <PackageVersion Include="Verify.XUnit" Version="28.1.3" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.2.0" />
+    <PackageVersion Include="Verify.XUnit" Version="22.8.0" />
+    <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.17.0" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Test262Harness" Version="1.0.1" />
     <PackageVersion Include="UnicodeInformation" Version="2.7.1" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />

--- a/benchmarks/Acornima.Benchmarks/Acornima.Benchmarks.csproj
+++ b/benchmarks/Acornima.Benchmarks/Acornima.Benchmarks.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageReference Include="Esprima" Version="3.0.5" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Esprima" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Components" Version="8.1.4" />
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/Acornima.Cli/Acornima.Cli.csproj
+++ b/samples/Acornima.Cli/Acornima.Cli.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <AssemblyName>acornima-cli</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/samples/Acornima.Cli/Acornima.Cli.csproj
+++ b/samples/Acornima.Cli/Acornima.Cli.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <AssemblyName>acornima-cli</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
@@ -10,9 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.*" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="6.0.*" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,7 +21,7 @@
   <!-- Configure polyfills -->
 
   <PropertyGroup>
-    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net462'">
+    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net472'">
       System.Runtime.CompilerServices.IsExternalInit;
     </PolySharpIncludeGeneratedTypes>
   </PropertyGroup>

--- a/samples/Acornima.Cli/Acornima.Cli.csproj
+++ b/samples/Acornima.Cli/Acornima.Cli.csproj
@@ -21,7 +21,7 @@
   <!-- Configure polyfills -->
 
   <PropertyGroup>
-    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net472'">
+    <PolySharpIncludeGeneratedTypes Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
       System.Runtime.CompilerServices.IsExternalInit;
     </PolySharpIncludeGeneratedTypes>
   </PropertyGroup>

--- a/samples/Acornima.Cli/Helpers/ConsoleExtensions.cs
+++ b/samples/Acornima.Cli/Helpers/ConsoleExtensions.cs
@@ -14,7 +14,7 @@ internal static class ConsoleExtensions
         }
 
         bool isWindowsOS;
-#if NET472
+#if NETFRAMEWORK
         isWindowsOS = true;
 #else
         isWindowsOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/samples/Acornima.Cli/Helpers/ConsoleExtensions.cs
+++ b/samples/Acornima.Cli/Helpers/ConsoleExtensions.cs
@@ -14,7 +14,7 @@ internal static class ConsoleExtensions
         }
 
         bool isWindowsOS;
-#if NET462
+#if NET472
         isWindowsOS = true;
 #else
         isWindowsOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/samples/JsxTranspiler/JsxTranspiler.csproj
+++ b/samples/JsxTranspiler/JsxTranspiler.csproj
@@ -26,7 +26,7 @@
   <!-- Configure polyfills -->
 
   <PropertyGroup>
-    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net462'">
+    <PolySharpIncludeGeneratedTypes Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
       System.Runtime.CompilerServices.IsExternalInit;
     </PolySharpIncludeGeneratedTypes>
   </PropertyGroup>

--- a/samples/JsxTranspiler/JsxTranspiler.csproj
+++ b/samples/JsxTranspiler/JsxTranspiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <AssemblyName>jsxt</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/samples/JsxTranspiler/JsxTranspiler.csproj
+++ b/samples/JsxTranspiler/JsxTranspiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <AssemblyName>jsxt</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
@@ -10,8 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.*" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/JsxTranspiler/generate.cmd
+++ b/samples/JsxTranspiler/generate.cmd
@@ -1,7 +1,13 @@
 @echo off
 
+SET TARGET_FRAMEWORK=%1
+IF [%TARGET_FRAMEWORK%] == [] (
+  SET TARGET_FRAMEWORK=net6.0
+)
+
 REM Transpile template
-dotnet run -f net6.0 -- --type module < template.jsx > template.mjs
+dotnet build -f %TARGET_FRAMEWORK%
+bin\debug\%TARGET_FRAMEWORK%\jsxt --type module < template.jsx > template.mjs
 
 REM Generate output from template
 node generate.mjs

--- a/samples/JsxTranspiler/generate.cmd
+++ b/samples/JsxTranspiler/generate.cmd
@@ -7,7 +7,7 @@ IF [%TARGET_FRAMEWORK%] == [] (
 
 REM Transpile template
 dotnet build -f %TARGET_FRAMEWORK%
-bin\debug\%TARGET_FRAMEWORK%\jsxt --type module < template.jsx > template.mjs
+%~dp0\bin\debug\%TARGET_FRAMEWORK%\jsxt --type module < template.jsx > template.mjs
 
 REM Generate output from template
 node generate.mjs

--- a/src/Acornima.Extras/Acornima.Extras.csproj
+++ b/src/Acornima.Extras/Acornima.Extras.csproj
@@ -57,7 +57,7 @@
   <!-- Configure polyfills -->
 
   <PropertyGroup>
-    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <PolySharpIncludeGeneratedTypes Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
       System.Runtime.CompilerServices.IsExternalInit;
       System.Runtime.CompilerServices.SkipLocalsInitAttribute
     </PolySharpIncludeGeneratedTypes>

--- a/src/Acornima.Extras/Acornima.Extras.csproj
+++ b/src/Acornima.Extras/Acornima.Extras.csproj
@@ -13,11 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Acornima\Acornima.csproj" />
     <ProjectReference Include="..\Acornima.SourceGenerators\Acornima.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/src/Acornima.SourceGenerators/Acornima.SourceGenerators.csproj
+++ b/src/Acornima.SourceGenerators/Acornima.SourceGenerators.csproj
@@ -9,9 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Configure polyfills -->

--- a/src/Acornima/Acornima.csproj
+++ b/src/Acornima/Acornima.csproj
@@ -12,16 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Acornima/Acornima.csproj
+++ b/src/Acornima/Acornima.csproj
@@ -11,12 +11,12 @@
     <PackageTags>javascript, ecmascript, parser</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Memory" />
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
+    <PackageReference Include="System.Memory" VersionOverride="4.5.5" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+   <PackageReference Include="System.Runtime.CompilerServices.Unsafe" VersionOverride="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -73,13 +73,13 @@
   <!-- Configure polyfills -->
 
   <PropertyGroup>
-    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
+    <PolySharpIncludeGeneratedTypes Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
       System.Runtime.CompilerServices.CallerArgumentExpressionAttribute;
       System.Runtime.CompilerServices.IsExternalInit;
       System.Runtime.CompilerServices.SkipLocalsInitAttribute
     </PolySharpIncludeGeneratedTypes>
 
-    <PolySharpIncludeGeneratedTypes Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PolySharpIncludeGeneratedTypes Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
       $(PolySharpIncludeGeneratedTypes);
       System.Diagnostics.CodeAnalysis.NotNullAttribute;
       System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute;

--- a/test/Acornima.Tests.SourceGenerators/Acornima.Tests.SourceGenerators.csproj
+++ b/test/Acornima.Tests.SourceGenerators/Acornima.Tests.SourceGenerators.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" Version="3.3.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Version="4.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Verify.XUnit" Version="23.7.2" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.analyzers" Version="1.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.5.7" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Verify.XUnit" />
+    <PackageReference Include="Verify.SourceGenerators" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Acornima.Tests.Test262/.config/dotnet-tools.json
+++ b/test/Acornima.Tests.Test262/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "test262harness.console": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "commands": [
         "test262"
       ]

--- a/test/Acornima.Tests.Test262/Acornima.Tests.Test262.csproj
+++ b/test/Acornima.Tests.Test262/Acornima.Tests.Test262.csproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" PrivateAssets="all" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-      <PackageReference Include="NUnit" Version="4.0.1" />
-      <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-      <PackageReference Include="Spectre.Console" Version="0.48.0" />
-      <PackageReference Include="Test262Harness" Version="1.0.0" />
+      <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="NUnit" />
+      <PackageReference Include="NUnit3TestAdapter" />
+      <PackageReference Include="Spectre.Console" />
+      <PackageReference Include="Test262Harness" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Acornima.Tests/Acornima.Tests.csproj
+++ b/test/Acornima.Tests/Acornima.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffEngine" VersionOverride="13.0.2" />
+    <PackageReference Include="DiffEngine" />
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/test/Acornima.Tests/Acornima.Tests.csproj
+++ b/test/Acornima.Tests/Acornima.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffEngine" />
+    <PackageReference Include="DiffEngine" VersionOverride="13.0.2" />
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <PackageReference Include="System.ValueTuple" />
+    <PackageReference Include="System.ValueTuple" VersionOverride="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Acornima.Tests/Acornima.Tests.csproj
+++ b/test/Acornima.Tests/Acornima.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Karambolo.Public.snk</AssemblyOriginatorKeyFile>
     <DefaultItemExcludes>Fixtures.RegExp\Generator\**;$(DefaultItemExcludes)</DefaultItemExcludes>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffEngine" />
+    <PackageReference Include="DiffEngine" VersionOverride="13.0.2" />
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Newtonsoft.Json" />
@@ -23,6 +23,10 @@
     <PackageReference Include="xunit.analyzers" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="xunit.runner.console" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <PackageReference Include="System.ValueTuple" />
   </ItemGroup>
 
 </Project>

--- a/test/Acornima.Tests/Acornima.Tests.csproj
+++ b/test/Acornima.Tests/Acornima.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Karambolo.Public.snk</AssemblyOriginatorKeyFile>
     <DefaultItemExcludes>Fixtures.RegExp\Generator\**;$(DefaultItemExcludes)</DefaultItemExcludes>
@@ -14,19 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffEngine" Version="13.0.2" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="UnicodeInformation" Version="2.7.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.analyzers" Version="1.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="all" />
-    <PackageReference Include="xunit.runner.console" Version="2.7.0" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="DiffEngine" />
+    <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="UnicodeInformation" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.console" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* all versions in `Directory.Packages.props`
* use `net472` for executable projects (no nasty value tuple requirements)
* latest versions of libraries