### PR TITLE
Upgrade dependencies and remove NET 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0
             8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack, Publish'
         run: ./build.cmd Compile Test Pack Publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,10 @@ on:
     paths:
       - '**/*'
 
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   macos-latest:
     name: macos-latest
@@ -32,8 +36,8 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0
             8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
@@ -44,8 +48,8 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0
             8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack
@@ -56,8 +60,8 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0
             8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Compile, Test, Pack'
         run: ./build.cmd Compile Test Pack

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,9 +10,9 @@
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
@@ -28,6 +28,6 @@
   <ItemGroup>
     <!-- global private assets -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
+    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
   </ItemGroup>
 </Project>

--- a/benchmarks/Acornima.Benchmarks/Acornima.Benchmarks.csproj
+++ b/benchmarks/Acornima.Benchmarks/Acornima.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Karambolo.Public.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -14,7 +14,8 @@ using Nuke.Components;
         OnPullRequestIncludePaths = ["**/*"],
         PublishArtifacts = false,
         InvokedTargets = [nameof(ICompile.Compile), nameof(ITest.Test), nameof(IPack.Pack)],
-        CacheKeyFiles = []
+        CacheKeyFiles = [],
+        ConcurrencyCancelInProgress = true
     )
 ]
 [CustomGitHubActions(
@@ -42,7 +43,7 @@ class CustomGitHubActionsAttribute : GitHubActionsAttribute
         var job = base.GetJobs(image, relevantTargets);
         var newSteps = new List<GitHubActionsStep>(job.Steps);
         // only need to list the ones that are missing from default image
-        newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["6.0", "8.0"]));
+        newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["8.0", "9.0"]));
         job.Steps = newSteps.ToArray();
         return job;
     }

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Components" Version="8.1.4" />
+    <PackageReference Include="Nuke.Components" Version="9.0.4" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
   </ItemGroup>
 

--- a/samples/Acornima.Cli/Acornima.Cli.csproj
+++ b/samples/Acornima.Cli/Acornima.Cli.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>acornima-cli</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/samples/JsxTranspiler/JsxTranspiler.csproj
+++ b/samples/JsxTranspiler/JsxTranspiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <AssemblyName>jsxt</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/src/Acornima.Extras/Acornima.Extras.csproj
+++ b/src/Acornima.Extras/Acornima.Extras.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Acornima</RootNamespace>
-    <TargetFrameworks>net8.0;net6.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <AssemblyTitle>Acornima.Extras</AssemblyTitle>

--- a/src/Acornima/Acornima.csproj
+++ b/src/Acornima/Acornima.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <AssemblyTitle>Acornima</AssemblyTitle>

--- a/test/Acornima.Tests.SourceGenerators/Acornima.Tests.SourceGenerators.csproj
+++ b/test/Acornima.Tests.SourceGenerators/Acornima.Tests.SourceGenerators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Acornima.Tests/Acornima.Tests.csproj
+++ b/test/Acornima.Tests/Acornima.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Karambolo.Public.snk</AssemblyOriginatorKeyFile>

--- a/test/Acornima.Tests/Acornima.Tests.csproj
+++ b/test/Acornima.Tests/Acornima.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\src\Karambolo.Public.snk</AssemblyOriginatorKeyFile>

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -88,9 +88,9 @@ public partial class ParserTests
 
         var parser = new Parser();
 #if DEBUG
-        const int depth = 395;
+        const int depth = 400;
 #else
-        const int depth = 1000;
+        const int depth = 975;
 #endif
         var input = $"if ({new string('(', depth)}true{new string(')', depth)}) {{ }}";
         parser.ParseScript(input);

--- a/test/Acornima.Tests/RegExpTests.cs
+++ b/test/Acornima.Tests/RegExpTests.cs
@@ -148,7 +148,10 @@ public partial class RegExpTests
     [InlineData(@"(?![^\\x28]*\\x29)", false, false)]
     [InlineData(@"(?<!(Saturday|Sunday))", false, false)]
     [InlineData(@"(?:x)", true, true)]
-#if NET7_0_OR_GREATER
+#if NET9_0_OR_GREATER
+    [InlineData(@"(?![^\\x28]*\\x29)", true, true)]
+    [InlineData(@"(?<!(Saturday|Sunday))", true, true)]
+#elif NET7_0_OR_GREATER
     [InlineData(@"(?![^\\x28]*\\x29)", true, false)]
     [InlineData(@"(?<!(Saturday|Sunday))", true, false)]
 #else


### PR DESCRIPTION
If someone would ever still need NET 6, they would just fall back to netstandard. Now cancelling old jobs for new pushes for same PR.