### PR TITLE
Add source-phase-imports and import-defer parsing

### DIFF
--- a/src/Acornima.Extras/AstToJavaScriptConverter.cs
+++ b/src/Acornima.Extras/AstToJavaScriptConverter.cs
@@ -1062,6 +1062,17 @@ public partial class AstToJavaScriptConverter : AstVisitor
     {
         Writer.WriteKeyword("import", TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
 
+        if (node.Phase != ImportPhase.None)
+        {
+            var phaseKeyword = node.Phase switch
+            {
+                ImportPhase.Source => "source",
+                ImportPhase.Defer => "defer",
+                _ => "unknown"
+            };
+            Writer.WriteKeyword(phaseKeyword, TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
+        }
+
         // Specifiers need special care because of the unusual syntax.
 
         _writeContext.SetNodeProperty(nameof(node.Specifiers), static node => ref node.As<ImportDeclaration>().Specifiers);
@@ -1138,6 +1149,18 @@ public partial class AstToJavaScriptConverter : AstVisitor
     protected internal override object? VisitImportExpression(ImportExpression node)
     {
         Writer.WriteKeyword("import", ref _writeContext);
+
+        if (node.Phase != ImportPhase.None)
+        {
+            Writer.WritePunctuator(".", TokenFlags.InBetween, ref _writeContext);
+            var phaseKeyword = node.Phase switch
+            {
+                ImportPhase.Source => "source",
+                ImportPhase.Defer => "defer",
+                _ => "unknown"
+            };
+            Writer.WriteKeyword(phaseKeyword, ref _writeContext);
+        }
 
         Writer.WritePunctuator("(", TokenFlags.Leading, ref _writeContext);
 

--- a/src/Acornima.Extras/AstToJavaScriptConverter.cs
+++ b/src/Acornima.Extras/AstToJavaScriptConverter.cs
@@ -1064,7 +1064,7 @@ public partial class AstToJavaScriptConverter : AstVisitor
 
         if (node.Phase != ImportPhase.None)
         {
-            Writer.WriteKeyword(node.Phase.GetImportPhaseToken(), TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
+            Writer.WriteKeyword(ImportDeclaration.GetImportPhaseToken(node.Phase)!, TokenFlags.TrailingSpaceRecommended, ref _writeContext);
         }
 
         // Specifiers need special care because of the unusual syntax.
@@ -1147,7 +1147,7 @@ public partial class AstToJavaScriptConverter : AstVisitor
         if (node.Phase != ImportPhase.None)
         {
             Writer.WritePunctuator(".", TokenFlags.InBetween, ref _writeContext);
-            Writer.WriteKeyword(node.Phase.GetImportPhaseToken(), ref _writeContext);
+            Writer.WriteKeyword(ImportDeclaration.GetImportPhaseToken(node.Phase)!, ref _writeContext);
         }
 
         Writer.WritePunctuator("(", TokenFlags.Leading, ref _writeContext);

--- a/src/Acornima.Extras/AstToJavaScriptConverter.cs
+++ b/src/Acornima.Extras/AstToJavaScriptConverter.cs
@@ -1064,13 +1064,7 @@ public partial class AstToJavaScriptConverter : AstVisitor
 
         if (node.Phase != ImportPhase.None)
         {
-            var phaseKeyword = node.Phase switch
-            {
-                ImportPhase.Source => "source",
-                ImportPhase.Defer => "defer",
-                _ => "unknown"
-            };
-            Writer.WriteKeyword(phaseKeyword, TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
+            Writer.WriteKeyword(node.Phase.GetImportPhaseToken(), TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
         }
 
         // Specifiers need special care because of the unusual syntax.
@@ -1153,13 +1147,7 @@ public partial class AstToJavaScriptConverter : AstVisitor
         if (node.Phase != ImportPhase.None)
         {
             Writer.WritePunctuator(".", TokenFlags.InBetween, ref _writeContext);
-            var phaseKeyword = node.Phase switch
-            {
-                ImportPhase.Source => "source",
-                ImportPhase.Defer => "defer",
-                _ => "unknown"
-            };
-            Writer.WriteKeyword(phaseKeyword, ref _writeContext);
+            Writer.WriteKeyword(node.Phase.GetImportPhaseToken(), ref _writeContext);
         }
 
         Writer.WritePunctuator("(", TokenFlags.Leading, ref _writeContext);

--- a/src/Acornima.Extras/AstToJsonConverter.cs
+++ b/src/Acornima.Extras/AstToJsonConverter.cs
@@ -184,6 +184,25 @@ public class AstToJsonConverter : AstVisitor
         Member(name, value);
     }
 
+    protected void Member(string name, ImportPhase phase)
+    {
+        Member(name);
+
+        if (phase == ImportPhase.None)
+        {
+            _writer.Null();
+        }
+        else
+        {
+            _writer.String(phase switch
+            {
+                ImportPhase.Source => "source",
+                ImportPhase.Defer => "defer",
+                _ => "unknown"
+            });
+        }
+    }
+
     protected void Member<T>(string name, in NodeList<T> nodes) where T : Node?
     {
         Member(name);
@@ -642,6 +661,10 @@ public class AstToJsonConverter : AstVisitor
         {
             Member("specifiers", node.Specifiers);
             Member("source", node.Source);
+            if (node.Phase != ImportPhase.None)
+            {
+                Member("phase", node.Phase);
+            }
             if (node.Attributes.Count > 0)
             {
                 Member("attributes", node.Attributes);
@@ -666,6 +689,10 @@ public class AstToJsonConverter : AstVisitor
         using (StartNodeObject(node))
         {
             Member("source", node.Source);
+            if (node.Phase != ImportPhase.None)
+            {
+                Member("phase", node.Phase);
+            }
 
             if (node.Options is not null)
             {

--- a/src/Acornima.Extras/AstToJsonConverter.cs
+++ b/src/Acornima.Extras/AstToJsonConverter.cs
@@ -186,16 +186,11 @@ public class AstToJsonConverter : AstVisitor
 
     protected void Member(string name, ImportPhase phase)
     {
-        Member(name);
+        var value = phase is >= ImportPhase.None and <= ImportPhase.Defer
+            ? ImportDeclaration.GetImportPhaseToken(phase)
+            : "unknown";
 
-        if (phase == ImportPhase.None)
-        {
-            _writer.Null();
-        }
-        else
-        {
-            _writer.String(phase.GetImportPhaseToken());
-        }
+        Member(name, value);
     }
 
     protected void Member<T>(string name, in NodeList<T> nodes) where T : Node?

--- a/src/Acornima.Extras/AstToJsonConverter.cs
+++ b/src/Acornima.Extras/AstToJsonConverter.cs
@@ -194,12 +194,7 @@ public class AstToJsonConverter : AstVisitor
         }
         else
         {
-            _writer.String(phase switch
-            {
-                ImportPhase.Source => "source",
-                ImportPhase.Defer => "defer",
-                _ => "unknown"
-            });
+            _writer.String(phase.GetImportPhaseToken());
         }
     }
 

--- a/src/Acornima/Ast/ImportDeclaration.cs
+++ b/src/Acornima/Ast/ImportDeclaration.cs
@@ -12,11 +12,19 @@ public sealed partial class ImportDeclaration : ImportOrExportDeclaration
         in NodeList<ImportDeclarationSpecifier> specifiers,
         StringLiteral source,
         in NodeList<ImportAttribute> attributes)
+        : this(specifiers, source, attributes, ImportPhase.None) { }
+
+    public ImportDeclaration(
+        in NodeList<ImportDeclarationSpecifier> specifiers,
+        StringLiteral source,
+        in NodeList<ImportAttribute> attributes,
+        ImportPhase phase)
         : base(NodeType.ImportDeclaration)
     {
         _specifiers = specifiers;
         Source = source;
         _attributes = attributes;
+        Phase = phase;
     }
 
     /// <remarks>
@@ -25,9 +33,10 @@ public sealed partial class ImportDeclaration : ImportOrExportDeclaration
     public ref readonly NodeList<ImportDeclarationSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _specifiers; }
     public StringLiteral Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public ref readonly NodeList<ImportAttribute> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _attributes; }
+    public ImportPhase Phase { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-    private static ImportDeclaration Rewrite(in NodeList<ImportDeclarationSpecifier> specifiers, StringLiteral source, in NodeList<ImportAttribute> attributes)
+    private ImportDeclaration Rewrite(in NodeList<ImportDeclarationSpecifier> specifiers, StringLiteral source, in NodeList<ImportAttribute> attributes)
     {
-        return new ImportDeclaration(specifiers, source, attributes);
+        return new ImportDeclaration(specifiers, source, attributes, Phase);
     }
 }

--- a/src/Acornima/Ast/ImportDeclaration.cs
+++ b/src/Acornima/Ast/ImportDeclaration.cs
@@ -1,10 +1,21 @@
 using System.Runtime.CompilerServices;
+using Acornima.Helpers;
 
 namespace Acornima.Ast;
+
+using static ExceptionHelper;
 
 [VisitableNode(ChildProperties = new[] { nameof(Specifiers), nameof(Source), nameof(Attributes) })]
 public sealed partial class ImportDeclaration : ImportOrExportDeclaration
 {
+    public static string? GetImportPhaseToken(ImportPhase phase) => phase switch
+    {
+        ImportPhase.None => null,
+        ImportPhase.Source => "source",
+        ImportPhase.Defer => "defer",
+        _ => ThrowArgumentOutOfRangeException(nameof(phase), phase.ToString(), null)
+    };
+
     private readonly NodeList<ImportDeclarationSpecifier> _specifiers;
     private readonly NodeList<ImportAttribute> _attributes;
 

--- a/src/Acornima/Ast/ImportExpression.cs
+++ b/src/Acornima/Ast/ImportExpression.cs
@@ -6,20 +6,25 @@ namespace Acornima.Ast;
 public sealed partial class ImportExpression : Expression
 {
     public ImportExpression(Expression source)
-        : this(source, null) { }
+        : this(source, null, ImportPhase.None) { }
 
     public ImportExpression(Expression source, Expression? options)
+        : this(source, options, ImportPhase.None) { }
+
+    public ImportExpression(Expression source, Expression? options, ImportPhase phase)
         : base(NodeType.ImportExpression)
     {
         Source = source;
         Options = options;
+        Phase = phase;
     }
 
     public Expression Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public Expression? Options { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public ImportPhase Phase { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-    private static ImportExpression Rewrite(Expression source, Expression? options)
+    private ImportExpression Rewrite(Expression source, Expression? options)
     {
-        return new ImportExpression(source, options);
+        return new ImportExpression(source, options, Phase);
     }
 }

--- a/src/Acornima/Ast/ImportPhase.cs
+++ b/src/Acornima/Ast/ImportPhase.cs
@@ -1,25 +1,8 @@
-using Acornima.Helpers;
-
 namespace Acornima.Ast;
-
-using static ExceptionHelper;
 
 public enum ImportPhase
 {
     None,
     Source,
     Defer
-}
-
-internal static class ImportPhaseExtensions
-{
-    public static string GetImportPhaseToken(this ImportPhase phase)
-    {
-        return phase switch
-        {
-            ImportPhase.Source => "source",
-            ImportPhase.Defer => "defer",
-            _ => ThrowArgumentOutOfRangeException<string>(nameof(phase), phase.ToString(), null)
-        };
-    }
 }

--- a/src/Acornima/Ast/ImportPhase.cs
+++ b/src/Acornima/Ast/ImportPhase.cs
@@ -1,0 +1,8 @@
+namespace Acornima.Ast;
+
+public enum ImportPhase
+{
+    None,
+    Source,
+    Defer
+}

--- a/src/Acornima/Ast/ImportPhase.cs
+++ b/src/Acornima/Ast/ImportPhase.cs
@@ -1,8 +1,25 @@
+using Acornima.Helpers;
+
 namespace Acornima.Ast;
+
+using static ExceptionHelper;
 
 public enum ImportPhase
 {
     None,
     Source,
     Defer
+}
+
+internal static class ImportPhaseExtensions
+{
+    public static string GetImportPhaseToken(this ImportPhase phase)
+    {
+        return phase switch
+        {
+            ImportPhase.Source => "source",
+            ImportPhase.Defer => "defer",
+            _ => ThrowArgumentOutOfRangeException<string>(nameof(phase), phase.ToString(), null)
+        };
+    }
 }

--- a/src/Acornima/ExperimentalESFeatures.cs
+++ b/src/Acornima/ExperimentalESFeatures.cs
@@ -42,9 +42,9 @@ public enum ExperimentalESFeatures
     SourcePhaseImports = 1 << 5,
 
     /// <summary>
-    /// Import defer feature as specified by this <seealso href="https://github.com/tc39/proposal-defer-import-eval">proposal</seealso>. Available only when <see cref="ParserOptions.EcmaVersion"/> >= ES2020.
+    /// Deferring module evaluation feature as specified by this <seealso href="https://github.com/tc39/proposal-defer-import-eval">proposal</seealso>. Available only when <see cref="ParserOptions.EcmaVersion"/> >= ES2020.
     /// </summary>
-    ImportDefer = 1 << 6,
+    DeferImportEvaluation = 1 << 6,
 
     All = Decorators
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -54,5 +54,5 @@ public enum ExperimentalESFeatures
         | RegExpModifiers
 #pragma warning restore CS0618 // Type or member is obsolete
         | SourcePhaseImports
-        | ImportDefer
+        | DeferImportEvaluation
 }

--- a/src/Acornima/ExperimentalESFeatures.cs
+++ b/src/Acornima/ExperimentalESFeatures.cs
@@ -36,6 +36,16 @@ public enum ExperimentalESFeatures
     [Obsolete($"This language feature is part of the standard since ES2025, so it will be removed from {nameof(ExperimentalESFeatures)} in the next major version.")]
     RegExpModifiers = 1 << 4,
 
+    /// <summary>
+    /// Source phase imports feature as specified by this <seealso href="https://github.com/tc39/proposal-source-phase-imports">proposal</seealso>. Available only when <see cref="ParserOptions.EcmaVersion"/> >= ES2020.
+    /// </summary>
+    SourcePhaseImports = 1 << 5,
+
+    /// <summary>
+    /// Import defer feature as specified by this <seealso href="https://github.com/tc39/proposal-defer-import-eval">proposal</seealso>. Available only when <see cref="ParserOptions.EcmaVersion"/> >= ES2020.
+    /// </summary>
+    ImportDefer = 1 << 6,
+
     All = Decorators
 #pragma warning disable CS0618 // Type or member is obsolete
         | ImportAttributes
@@ -43,4 +53,6 @@ public enum ExperimentalESFeatures
         | ExplicitResourceManagement
         | RegExpModifiers
 #pragma warning restore CS0618 // Type or member is obsolete
+        | SourcePhaseImports
+        | ImportDefer
 }

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -1098,12 +1098,40 @@ public partial class Parser
             Unexpected();
         }
 
-        // Parse node.source — import.source() and import.defer() take exactly one argument.
+        // Parse node.source.
         var source = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
 
-        Expect(TokenType.ParenRight);
+        // import.source() takes exactly one argument (per tc39.es/proposal-source-phase-imports).
+        // import.defer() reuses ImportCallArguments, so it takes an optional second argument (per tc39.es/proposal-defer-import-eval).
+        Expression? options = null;
+        if (phase == ImportPhase.Defer
+            && _tokenizerOptions.AllowImportAttributes()
+            && Eat(TokenType.Comma) && _tokenizer._type != TokenType.ParenRight)
+        {
+            options = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
+            if (Eat(TokenType.Comma))
+            {
+                AfterTrailingComma(TokenType.ParenRight, notNext: true);
+            }
+            Expect(TokenType.ParenRight);
+        }
+        // Verify ending.
+        else if (!Eat(TokenType.ParenRight))
+        {
+            var errorState = new TokenState(_tokenizer);
 
-        return FinishNode(startMarker, new ImportExpression(source, options: null, phase));
+            if (phase == ImportPhase.Defer && Eat(TokenType.Comma) && Eat(TokenType.ParenRight))
+            {
+                // RaiseRecoverable(errorPos, "Trailing comma is not allowed in import()"); // original acornjs error reporting
+                RaiseRecoverable(errorState.Position, errorState.TokenType, errorState.TokenValue);
+            }
+            else
+            {
+                Unexpected(errorState);
+            }
+        }
+
+        return FinishNode(startMarker, new ImportExpression(source, options, phase));
     }
 
     private Expression ParseParenExpression()

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -992,7 +992,7 @@ public partial class Parser
         {
             var meta = FinishNode(startMarker, new Identifier(TokenType.Import.Label));
 
-            return ParseImportMeta(startMarker, meta);
+            return ParseImportMetaOrPhase(startMarker, meta, context);
         }
         else
         {
@@ -1039,7 +1039,7 @@ public partial class Parser
         return FinishNode(startMarker, new ImportExpression(source, attributes));
     }
 
-    private MetaProperty ParseImportMeta(in Marker startMarker, Identifier meta)
+    private Expression ParseImportMetaOrPhase(in Marker startMarker, Identifier meta, ExpressionContext context)
     {
         // https://github.com/acornjs/acorn/blob/8.11.3/acorn/src/expression.js > `pp.parseImportMeta = function`
 
@@ -1048,23 +1048,61 @@ public partial class Parser
         var containsEsc = _tokenizer._containsEscape;
         var property = ParseIdentifier(liberal: true);
 
-        if (property.Name != "meta")
+        if (property.Name == "meta")
         {
-            // RaiseRecoverable(property.Start, "The only valid meta property for import is 'import.meta'"); // original acornjs error reporting
-            Unexpected(property.Start, TokenType.Name, property.Name);
-        }
-        if (containsEsc)
-        {
-            // RaiseRecoverable(property.Start, "'import.meta' must not contain escaped characters"); // original acornjs error reporting
-            RaiseRecoverable(property.Start, InvalidEscapedMetaProperty, new object[] { "import.meta" });
-        }
-        if (!_inModule && !_options._allowImportExportEverywhere)
-        {
-            //RaiseRecoverable(property.Start, "Cannot use 'import.meta' outside a module"); // original acornjs error reporting
-            Raise(property.Start, ImportMetaOutsideModule);
+            if (containsEsc)
+            {
+                // RaiseRecoverable(property.Start, "'import.meta' must not contain escaped characters"); // original acornjs error reporting
+                RaiseRecoverable(property.Start, InvalidEscapedMetaProperty, new object[] { "import.meta" });
+            }
+            if (!_inModule && !_options._allowImportExportEverywhere)
+            {
+                //RaiseRecoverable(property.Start, "Cannot use 'import.meta' outside a module"); // original acornjs error reporting
+                Raise(property.Start, ImportMetaOutsideModule);
+            }
+
+            return FinishNode(startMarker, new MetaProperty(meta, property));
         }
 
-        return FinishNode(startMarker, new MetaProperty(meta, property));
+        if (_tokenizerOptions.AllowSourcePhaseImports() && property.Name == "source" && !containsEsc)
+        {
+            return ParseDynamicImportPhase(startMarker, ImportPhase.Source, context);
+        }
+
+        if (_tokenizerOptions.AllowImportDefer() && property.Name == "defer" && !containsEsc)
+        {
+            return ParseDynamicImportPhase(startMarker, ImportPhase.Defer, context);
+        }
+
+        // RaiseRecoverable(property.Start, "The only valid meta property for import is 'import.meta'"); // original acornjs error reporting
+        Unexpected(property.Start, TokenType.Name, property.Name);
+        return default!; // unreachable
+    }
+
+    private ImportExpression ParseDynamicImportPhase(in Marker startMarker, ImportPhase phase, ExpressionContext context)
+    {
+        if ((context & ExpressionContext.ForNew) != 0)
+        {
+            Unexpected();
+        }
+
+        Expect(TokenType.ParenLeft);
+
+        if (_tokenizer._type == TokenType.ParenRight)
+        {
+            Unexpected();
+        }
+
+        if (_tokenizer._type == TokenType.Ellipsis)
+        {
+            Unexpected();
+        }
+
+        var source = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
+
+        Expect(TokenType.ParenRight);
+
+        return FinishNode(startMarker, new ImportExpression(source, options: null, phase));
     }
 
     private Expression ParseParenExpression()

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -1098,11 +1098,37 @@ public partial class Parser
             Unexpected();
         }
 
+        // Parse node.source.
         var source = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
 
-        Expect(TokenType.ParenRight);
+        Expression? options = null;
+        if (_tokenizerOptions.AllowImportAttributes()
+            && Eat(TokenType.Comma) && _tokenizer._type != TokenType.ParenRight)
+        {
+            options = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
+            if (Eat(TokenType.Comma))
+            {
+                AfterTrailingComma(TokenType.ParenRight, notNext: true);
+            }
+            Expect(TokenType.ParenRight);
+        }
+        // Verify ending.
+        else if (!Eat(TokenType.ParenRight))
+        {
+            var errorState = new TokenState(_tokenizer);
 
-        return FinishNode(startMarker, new ImportExpression(source, options: null, phase));
+            if (Eat(TokenType.Comma) && Eat(TokenType.ParenRight))
+            {
+                // RaiseRecoverable(errorPos, "Trailing comma is not allowed in import()"); // original acornjs error reporting
+                RaiseRecoverable(errorState.Position, errorState.TokenType, errorState.TokenValue);
+            }
+            else
+            {
+                Unexpected(errorState);
+            }
+        }
+
+        return FinishNode(startMarker, new ImportExpression(source, options, phase));
     }
 
     private Expression ParseParenExpression()

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -1098,37 +1098,12 @@ public partial class Parser
             Unexpected();
         }
 
-        // Parse node.source.
+        // Parse node.source — import.source() and import.defer() take exactly one argument.
         var source = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
 
-        Expression? options = null;
-        if (_tokenizerOptions.AllowImportAttributes()
-            && Eat(TokenType.Comma) && _tokenizer._type != TokenType.ParenRight)
-        {
-            options = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
-            if (Eat(TokenType.Comma))
-            {
-                AfterTrailingComma(TokenType.ParenRight, notNext: true);
-            }
-            Expect(TokenType.ParenRight);
-        }
-        // Verify ending.
-        else if (!Eat(TokenType.ParenRight))
-        {
-            var errorState = new TokenState(_tokenizer);
+        Expect(TokenType.ParenRight);
 
-            if (Eat(TokenType.Comma) && Eat(TokenType.ParenRight))
-            {
-                // RaiseRecoverable(errorPos, "Trailing comma is not allowed in import()"); // original acornjs error reporting
-                RaiseRecoverable(errorState.Position, errorState.TokenType, errorState.TokenValue);
-            }
-            else
-            {
-                Unexpected(errorState);
-            }
-        }
-
-        return FinishNode(startMarker, new ImportExpression(source, options, phase));
+        return FinishNode(startMarker, new ImportExpression(source, options: null, phase));
     }
 
     private Expression ParseParenExpression()

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -1009,11 +1009,11 @@ public partial class Parser
         // Parse node.source.
         var source = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
 
-        Expression? attributes = null;
+        Expression? options = null;
         if (_tokenizerOptions.AllowImportAttributes()
             && Eat(TokenType.Comma) && _tokenizer._type != TokenType.ParenRight)
         {
-            attributes = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
+            options = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
             if (Eat(TokenType.Comma))
             {
                 AfterTrailingComma(TokenType.ParenRight, notNext: true);
@@ -1036,7 +1036,7 @@ public partial class Parser
             }
         }
 
-        return FinishNode(startMarker, new ImportExpression(source, attributes));
+        return FinishNode(startMarker, new ImportExpression(source, options, ImportPhase.None));
     }
 
     private Expression ParseImportMetaOrPhase(in Marker startMarker, Identifier meta, ExpressionContext context)
@@ -1064,19 +1064,27 @@ public partial class Parser
             return FinishNode(startMarker, new MetaProperty(meta, property));
         }
 
-        if (_tokenizerOptions.AllowSourcePhaseImports() && property.Name == "source" && !containsEsc)
+        if (_tokenizerOptions.AllowSourcePhaseImports() && property.Name == "source")
         {
+            if (containsEsc)
+            {
+                RaiseRecoverable(property.Start, InvalidEscapedMetaProperty, new object[] { "import.source" });
+            }
             return ParseDynamicImportPhase(startMarker, ImportPhase.Source, context);
         }
 
-        if (_tokenizerOptions.AllowImportDefer() && property.Name == "defer" && !containsEsc)
+        if (_tokenizerOptions.AllowDeferImportEvaluation() && property.Name == "defer")
         {
+            if (containsEsc)
+            {
+                RaiseRecoverable(property.Start, InvalidEscapedMetaProperty, new object[] { "import.defer" });
+            }
             return ParseDynamicImportPhase(startMarker, ImportPhase.Defer, context);
         }
 
         // RaiseRecoverable(property.Start, "The only valid meta property for import is 'import.meta'"); // original acornjs error reporting
         Unexpected(property.Start, TokenType.Name, property.Name);
-        return default!; // unreachable
+        return default!; // unreachable, just to keep the compiler happy
     }
 
     private ImportExpression ParseDynamicImportPhase(in Marker startMarker, ImportPhase phase, ExpressionContext context)
@@ -1122,7 +1130,6 @@ public partial class Parser
 
             if (phase == ImportPhase.Defer && Eat(TokenType.Comma) && Eat(TokenType.ParenRight))
             {
-                // RaiseRecoverable(errorPos, "Trailing comma is not allowed in import()"); // original acornjs error reporting
                 RaiseRecoverable(errorState.Position, errorState.TokenType, errorState.TokenValue);
             }
             else

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -2122,6 +2122,23 @@ public partial class Parser
 
         Next();
 
+        var phase = ImportPhase.None;
+
+        if (_tokenizerOptions.AllowSourcePhaseImports()
+            && IsContextual("source")
+            && !IsImportPhaseAmbiguousAsDefaultImport("source"))
+        {
+            phase = ImportPhase.Source;
+            Next(); // consume "source"
+        }
+        else if (_tokenizerOptions.AllowImportDefer()
+            && IsContextual("defer")
+            && IsDeferNamespaceImport())
+        {
+            phase = ImportPhase.Defer;
+            Next(); // consume "defer"
+        }
+
         NodeList<ImportDeclarationSpecifier> specifiers;
 
         if (_tokenizer._type == TokenType.String)
@@ -2146,7 +2163,42 @@ public partial class Parser
 
         Semicolon();
 
-        return FinishNode(startMarker, new ImportDeclaration(specifiers, source, NodeList.From(ref attributes)));
+        return FinishNode(startMarker, new ImportDeclaration(specifiers, source, NodeList.From(ref attributes), phase));
+    }
+
+    // Disambiguation for `import source X from "mod"` (source-phase import) vs `import source from "mod"` (regular default import).
+    // Returns true if the `source` (or `defer`) token is the binding name of a regular default import.
+    // Uses the pattern: `import <phase> from <string>` is a regular import; anything else with the phase keyword is a phase import.
+    private bool IsImportPhaseAmbiguousAsDefaultImport(string phaseKeyword)
+    {
+        var next = _tokenizer.NextTokenPosition(out var nextLine, out var nextLineStart);
+        var fromKeyword = "from";
+        var fromEndPos = next + fromKeyword.Length;
+        int after;
+
+        // Check if the next token after the phase keyword is "from"
+        if (fromEndPos < _tokenizer._endPosition
+            && _tokenizer._input.SliceBetween(next, fromEndPos) is "from"
+            && !Tokenizer.IsIdentifierChar(after = _tokenizer.FullCharCodeAt(fromEndPos), allowAstral: true)
+            && after != '\\')
+        {
+            // Check if the token after "from" is a string literal
+            var afterFrom = _tokenizer.NextTokenPositionAt(fromEndPos, ref nextLine, ref nextLineStart);
+            var ch = _tokenizer.CharCodeAt(afterFrom);
+            if (ch is '"' or '\'')
+            {
+                return true; // `import source from "mod"` — regular default import
+            }
+        }
+
+        return false; // source-phase import
+    }
+
+    // Returns true if `import defer *` is followed by `*`, indicating a deferred namespace import.
+    private bool IsDeferNamespaceImport()
+    {
+        var next = _tokenizer.NextTokenPosition(out _, out _);
+        return _tokenizer.CharCodeAt(next) == '*';
     }
 
     private ImportSpecifier ParseImportSpecifier()

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -2126,7 +2126,7 @@ public partial class Parser
 
         if (_tokenizerOptions.AllowSourcePhaseImports()
             && IsContextual("source")
-            && !IsImportPhaseAmbiguousAsDefaultImport("source"))
+            && !IsSourcePhaseAmbiguousAsDefaultImport())
         {
             phase = ImportPhase.Source;
             Next(); // consume "source"
@@ -2180,9 +2180,9 @@ public partial class Parser
     }
 
     // Disambiguation for `import source X from "mod"` (source-phase import) vs regular imports where `source` is just a binding name.
-    // Returns true if the phase keyword token is the binding name of a regular default import.
+    // Returns true if `source` is the binding name of a regular default import.
     // Regular import cases: `import source from "mod"`, `import source, { x } from "mod"`, `import source, * as ns from "mod"`.
-    private bool IsImportPhaseAmbiguousAsDefaultImport(string phaseKeyword)
+    private bool IsSourcePhaseAmbiguousAsDefaultImport()
     {
         var next = _tokenizer.NextTokenPosition(out var nextLine, out var nextLineStart);
 

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -2122,53 +2122,50 @@ public partial class Parser
 
         Next();
 
+        NodeList<ImportDeclarationSpecifier> specifiers;
         var phase = ImportPhase.None;
+
+        if (_tokenizer._type == TokenType.String)
+        {
+            // import '...'
+            specifiers = default;
+            goto ParseSource;
+        }
 
         if (_tokenizerOptions.AllowSourcePhaseImports()
             && IsContextual("source")
             && !IsSourcePhaseAmbiguousAsDefaultImport())
         {
             phase = ImportPhase.Source;
-            Next(); // consume "source"
-        }
-        else if (_tokenizerOptions.AllowImportDefer()
-            && IsContextual("defer")
-            && IsDeferNamespaceImport())
-        {
-            phase = ImportPhase.Defer;
-            Next(); // consume "defer"
-        }
+            Next();
 
-        NodeList<ImportDeclarationSpecifier> specifiers;
-
-        if (phase == ImportPhase.Source)
-        {
             // import source <binding> from "<specifier>"
             // Source phase only allows a single default binding (ImportedBinding).
             var nodes = new ArrayList<ImportDeclarationSpecifier>();
             nodes.Add(ParseImportDefaultSpecifier());
             specifiers = NodeList.From(ref nodes);
-            ExpectContextual("from");
-            if (_tokenizer._type != TokenType.String)
-            {
-                Unexpected();
-            }
-        }
-        else if (_tokenizer._type == TokenType.String)
-        {
-            // import '...'
-            specifiers = default;
-        }
-        else
-        {
-            specifiers = ParseImportSpecifiers();
-            ExpectContextual("from");
-            if (_tokenizer._type != TokenType.String)
-            {
-                Unexpected();
-            }
+
+            goto ParseFrom;
         }
 
+        if (_tokenizerOptions.AllowDeferImportEvaluation()
+            && IsContextual("defer")
+            && IsDeferNamespaceImport())
+        {
+            phase = ImportPhase.Defer;
+            Next();
+        }
+
+        specifiers = ParseImportSpecifiers();
+
+    ParseFrom:
+        ExpectContextual("from");
+        if (_tokenizer._type != TokenType.String)
+        {
+            Unexpected();
+        }
+
+    ParseSource:
         var source = ParseExprAtom(ref NullRef<DestructuringErrors>()).As<StringLiteral>();
         var attributes = _tokenizerOptions.AllowImportAttributes()
             ? ParseImportAttributes()
@@ -2203,9 +2200,8 @@ public partial class Parser
             && after != '\\')
         {
             // Check if the token after "from" is a string literal: `import source from "mod"`
-            var afterFrom = _tokenizer.NextTokenPositionAt(fromEndPos, ref nextLine, ref nextLineStart);
-            var ch = _tokenizer.CharCodeAt(afterFrom);
-            if (ch is '"' or '\'')
+            next = _tokenizer.NextTokenPositionAt(fromEndPos, ref nextLine, ref nextLineStart);
+            if (_tokenizer.CharCodeAt(next) is '"' or '\'')
             {
                 return true; // `import source from "mod"` — regular default import
             }

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -2141,7 +2141,20 @@ public partial class Parser
 
         NodeList<ImportDeclarationSpecifier> specifiers;
 
-        if (_tokenizer._type == TokenType.String)
+        if (phase == ImportPhase.Source)
+        {
+            // import source <binding> from "<specifier>"
+            // Source phase only allows a single default binding (ImportedBinding).
+            var nodes = new ArrayList<ImportDeclarationSpecifier>();
+            nodes.Add(ParseImportDefaultSpecifier());
+            specifiers = NodeList.From(ref nodes);
+            ExpectContextual("from");
+            if (_tokenizer._type != TokenType.String)
+            {
+                Unexpected();
+            }
+        }
+        else if (_tokenizer._type == TokenType.String)
         {
             // import '...'
             specifiers = default;

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -2179,14 +2179,21 @@ public partial class Parser
         return FinishNode(startMarker, new ImportDeclaration(specifiers, source, NodeList.From(ref attributes), phase));
     }
 
-    // Disambiguation for `import source X from "mod"` (source-phase import) vs `import source from "mod"` (regular default import).
-    // Returns true if the `source` (or `defer`) token is the binding name of a regular default import.
-    // Uses the pattern: `import <phase> from <string>` is a regular import; anything else with the phase keyword is a phase import.
+    // Disambiguation for `import source X from "mod"` (source-phase import) vs regular imports where `source` is just a binding name.
+    // Returns true if the phase keyword token is the binding name of a regular default import.
+    // Regular import cases: `import source from "mod"`, `import source, { x } from "mod"`, `import source, * as ns from "mod"`.
     private bool IsImportPhaseAmbiguousAsDefaultImport(string phaseKeyword)
     {
         var next = _tokenizer.NextTokenPosition(out var nextLine, out var nextLineStart);
-        var fromKeyword = "from";
-        var fromEndPos = next + fromKeyword.Length;
+
+        // `import source, ...` — source is a default binding followed by additional specifiers.
+        // Source-phase imports never have a comma after the phase keyword.
+        if (_tokenizer.CharCodeAt(next) == ',')
+        {
+            return true;
+        }
+
+        var fromEndPos = next + 4 /* "from".Length */;
         int after;
 
         // Check if the next token after the phase keyword is "from"
@@ -2195,7 +2202,7 @@ public partial class Parser
             && !Tokenizer.IsIdentifierChar(after = _tokenizer.FullCharCodeAt(fromEndPos), allowAstral: true)
             && after != '\\')
         {
-            // Check if the token after "from" is a string literal
+            // Check if the token after "from" is a string literal: `import source from "mod"`
             var afterFrom = _tokenizer.NextTokenPositionAt(fromEndPos, ref nextLine, ref nextLineStart);
             var ch = _tokenizer.CharCodeAt(afterFrom);
             if (ch is '"' or '\'')

--- a/src/Acornima/TokenizerOptions.cs
+++ b/src/Acornima/TokenizerOptions.cs
@@ -164,9 +164,9 @@ public record class TokenizerOptions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool AllowImportDefer()
+    internal bool AllowDeferImportEvaluation()
     {
         // NOTE: Dynamic import, which is part of this feature, is only available since ES2020.
-        return _ecmaVersion >= EcmaVersion.ES11 && (_experimentalESFeatures & ExperimentalESFeatures.ImportDefer) != 0;
+        return _ecmaVersion >= EcmaVersion.ES11 && (_experimentalESFeatures & ExperimentalESFeatures.DeferImportEvaluation) != 0;
     }
 }

--- a/src/Acornima/TokenizerOptions.cs
+++ b/src/Acornima/TokenizerOptions.cs
@@ -155,4 +155,18 @@ public record class TokenizerOptions
             || _ecmaVersion >= EcmaVersion.ES9 && (_experimentalESFeatures & ExperimentalESFeatures.RegExpModifiers) != 0;
 #pragma warning restore CS0618 // Type or member is obsolete
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool AllowSourcePhaseImports()
+    {
+        // NOTE: Dynamic import, which is part of this feature, is only available since ES2020.
+        return _ecmaVersion >= EcmaVersion.ES11 && (_experimentalESFeatures & ExperimentalESFeatures.SourcePhaseImports) != 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool AllowImportDefer()
+    {
+        // NOTE: Dynamic import, which is part of this feature, is only available since ES2020.
+        return _ecmaVersion >= EcmaVersion.ES11 && (_experimentalESFeatures & ExperimentalESFeatures.ImportDefer) != 0;
+    }
 }

--- a/test/Acornima.Tests.Test262/Test262Harness.settings.json
+++ b/test/Acornima.Tests.Test262/Test262Harness.settings.json
@@ -1,5 +1,5 @@
 {
-  "SuiteGitSha": "5c8206929d81b2d3d727ca6aac56c18358c8d790",
+  "SuiteGitSha": "2b2ecead6e828dd9af13a9ec72065e645724a50f",
   //"SuiteDirectory": "//mnt/c/work/test262",
   "TargetPath": "./Generated",
   "Namespace": "Acornima.Tests.Test262",

--- a/test/Acornima.Tests.Test262/Test262Harness.settings.json
+++ b/test/Acornima.Tests.Test262/Test262Harness.settings.json
@@ -5,10 +5,6 @@
   "Namespace": "Acornima.Tests.Test262",
   "Parallel": true,
   "ExcludedFeatures": [
-    "import-assertions",
-    "import-defer",
-    "json-modules",
-    "source-phase-imports"
   ],
   "ExcludedFlags": [],
   "ExcludedDirectories": [],

--- a/test/Acornima.Tests.Test262/Test262Test.cs
+++ b/test/Acornima.Tests.Test262/Test262Test.cs
@@ -10,6 +10,8 @@ public abstract partial class Test262Test
     private static readonly string[] s_testableExperimentalFeatures = new[]
     {
         "decorators",
+        "source-phase-imports",
+        "import-defer",
     };
 
     public static bool TestsExperimentalFeature(Test262File file)

--- a/test/Acornima.Tests/AstRewriterTests.cs
+++ b/test/Acornima.Tests/AstRewriterTests.cs
@@ -475,13 +475,13 @@ internal sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
         return ForceNewObjectByControlType((ImportDeclaration)base.VisitImportDeclaration(importDeclaration)!,
-            node => new ImportDeclaration(node.Specifiers, node.Source, importDeclaration.Attributes));
+            node => new ImportDeclaration(node.Specifiers, node.Source, importDeclaration.Attributes, importDeclaration.Phase));
     }
 
     protected internal override object? VisitImportExpression(ImportExpression importExpression)
     {
         return ForceNewObjectByControlType((ImportExpression)base.VisitImportExpression(importExpression)!,
-            node => new ImportExpression(node.Source, node.Options));
+            node => new ImportExpression(node.Source, node.Options, importExpression.Phase));
     }
 
     protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2613,7 +2613,7 @@ public partial class ParserTests
 
     private static Parser CreateImportPhasesParser()
     {
-        return new Parser(new ParserOptions { ExperimentalESFeatures = ExperimentalESFeatures.SourcePhaseImports | ExperimentalESFeatures.ImportDefer });
+        return new Parser(new ParserOptions { ExperimentalESFeatures = ExperimentalESFeatures.SourcePhaseImports | ExperimentalESFeatures.DeferImportEvaluation });
     }
 
     [Theory]

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2630,14 +2630,17 @@ public partial class ParserTests
         Assert.IsType<ImportDefaultSpecifier>(decl.Specifiers[0]);
     }
 
-    [Fact]
-    public void SourcePhaseImport_RegularImportWithSourceAsBinding()
+    [Theory]
+    [InlineData("import source from 'mod';", 1)]
+    [InlineData("import source, { x } from 'mod';", 2)]
+    [InlineData("import source, * as ns from 'mod';", 2)]
+    public void SourcePhaseImport_RegularImportWithSourceAsBinding(string code, int expectedSpecifierCount)
     {
         var parser = CreateImportPhasesParser();
-        var module = parser.ParseModule("import source from 'mod';");
+        var module = parser.ParseModule(code);
         var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
         Assert.Equal(ImportPhase.None, decl.Phase);
-        Assert.Single(decl.Specifiers);
+        Assert.Equal(expectedSpecifierCount, decl.Specifiers.Count);
         var spec = Assert.IsType<ImportDefaultSpecifier>(decl.Specifiers[0]);
         Assert.Equal("source", spec.Local.Name);
     }

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2698,8 +2698,6 @@ public partial class ParserTests
     [Theory]
     [InlineData("import.source('mod')")]
     [InlineData("import.defer('mod')")]
-    [InlineData("import.source('mod', { with: { type: 'json' } })")]
-    [InlineData("import.defer('mod', { with: { type: 'json' } })")]
     public void DynamicImportPhase_ValidForms(string code)
     {
         var parser = CreateImportPhasesParser();
@@ -2712,6 +2710,8 @@ public partial class ParserTests
     [Theory]
     [InlineData("import.source()")]
     [InlineData("import.defer()")]
+    [InlineData("import.source('mod', { with: { type: 'json' } })")]
+    [InlineData("import.defer('mod', { with: { type: 'json' } })")]
     [InlineData("new import.source('mod')")]
     [InlineData("new import.defer('mod')")]
     [InlineData("import.source(...['mod'])")]

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2698,6 +2698,7 @@ public partial class ParserTests
     [Theory]
     [InlineData("import.source('mod')")]
     [InlineData("import.defer('mod')")]
+    [InlineData("import.defer('mod', { with: { type: 'json' } })")]
     public void DynamicImportPhase_ValidForms(string code)
     {
         var parser = CreateImportPhasesParser();
@@ -2711,7 +2712,6 @@ public partial class ParserTests
     [InlineData("import.source()")]
     [InlineData("import.defer()")]
     [InlineData("import.source('mod', { with: { type: 'json' } })")]
-    [InlineData("import.defer('mod', { with: { type: 'json' } })")]
     [InlineData("new import.source('mod')")]
     [InlineData("new import.defer('mod')")]
     [InlineData("import.source(...['mod'])")]

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2669,13 +2669,17 @@ public partial class ParserTests
         Assert.IsType<ImportNamespaceSpecifier>(decl.Specifiers[0]);
     }
 
-    [Fact]
-    public void ImportDefer_RegularImportWithDeferAsBinding()
+    [Theory]
+    [InlineData("import defer from 'mod';", 1)]
+    [InlineData("import defer, { x } from 'mod';", 2)]
+    [InlineData("import defer, * as ns from 'mod';", 2)]
+    public void ImportDefer_RegularImportWithDeferAsBinding(string code, int expectedSpecifierCount)
     {
         var parser = CreateImportPhasesParser();
-        var module = parser.ParseModule("import defer from 'mod';");
+        var module = parser.ParseModule(code);
         var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
         Assert.Equal(ImportPhase.None, decl.Phase);
+        Assert.Equal(expectedSpecifierCount, decl.Specifiers.Count);
         var spec = Assert.IsType<ImportDefaultSpecifier>(decl.Specifiers[0]);
         Assert.Equal("defer", spec.Local.Name);
     }

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2608,4 +2608,126 @@ public partial class ParserTests
             _ => throw new InvalidOperationException()
         };
     }
+
+    #region Import Phases
+
+    private static Parser CreateImportPhasesParser()
+    {
+        return new Parser(new ParserOptions { ExperimentalESFeatures = ExperimentalESFeatures.SourcePhaseImports | ExperimentalESFeatures.ImportDefer });
+    }
+
+    [Theory]
+    [InlineData("import source x from 'mod';")]
+    [InlineData("import source source from 'mod';")]
+    [InlineData("import source from from 'mod';")]
+    public void SourcePhaseImport_ValidStaticForms(string code)
+    {
+        var parser = CreateImportPhasesParser();
+        var module = parser.ParseModule(code);
+        var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
+        Assert.Equal(ImportPhase.Source, decl.Phase);
+        Assert.Single(decl.Specifiers);
+        Assert.IsType<ImportDefaultSpecifier>(decl.Specifiers[0]);
+    }
+
+    [Fact]
+    public void SourcePhaseImport_RegularImportWithSourceAsBinding()
+    {
+        var parser = CreateImportPhasesParser();
+        var module = parser.ParseModule("import source from 'mod';");
+        var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
+        Assert.Equal(ImportPhase.None, decl.Phase);
+        Assert.Single(decl.Specifiers);
+        var spec = Assert.IsType<ImportDefaultSpecifier>(decl.Specifiers[0]);
+        Assert.Equal("source", spec.Local.Name);
+    }
+
+    [Theory]
+    [InlineData("import source { x } from 'mod';")]
+    [InlineData("import source * as ns from 'mod';")]
+    [InlineData("import source 'mod';")]
+    [InlineData("import source x, y from 'mod';")]
+    public void SourcePhaseImport_InvalidStaticForms(string code)
+    {
+        var parser = CreateImportPhasesParser();
+        Assert.Throws<SyntaxErrorException>(() => parser.ParseModule(code));
+    }
+
+    [Theory]
+    [InlineData("import defer * as ns from 'mod';")]
+    [InlineData("import defer * as ns from 'mod' with { };")]
+    public void ImportDefer_ValidStaticForms(string code)
+    {
+        var parser = CreateImportPhasesParser();
+        var module = parser.ParseModule(code);
+        var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
+        Assert.Equal(ImportPhase.Defer, decl.Phase);
+        Assert.Single(decl.Specifiers);
+        Assert.IsType<ImportNamespaceSpecifier>(decl.Specifiers[0]);
+    }
+
+    [Fact]
+    public void ImportDefer_RegularImportWithDeferAsBinding()
+    {
+        var parser = CreateImportPhasesParser();
+        var module = parser.ParseModule("import defer from 'mod';");
+        var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
+        Assert.Equal(ImportPhase.None, decl.Phase);
+        var spec = Assert.IsType<ImportDefaultSpecifier>(decl.Specifiers[0]);
+        Assert.Equal("defer", spec.Local.Name);
+    }
+
+    [Theory]
+    [InlineData("import defer x from 'mod';")]
+    [InlineData("import defer { x } from 'mod';")]
+    [InlineData("import defer x, * as ns from 'mod';")]
+    [InlineData("export defer * as ns from 'mod';")]
+    public void ImportDefer_InvalidStaticForms(string code)
+    {
+        var parser = CreateImportPhasesParser();
+        Assert.Throws<SyntaxErrorException>(() => parser.ParseModule(code));
+    }
+
+    [Theory]
+    [InlineData("import.source('mod')")]
+    [InlineData("import.defer('mod')")]
+    [InlineData("import.source('mod', { with: { type: 'json' } })")]
+    [InlineData("import.defer('mod', { with: { type: 'json' } })")]
+    public void DynamicImportPhase_ValidForms(string code)
+    {
+        var parser = CreateImportPhasesParser();
+        var program = parser.ParseScript(code);
+        var stmt = (ExpressionStatement)Assert.Single(program.Body);
+        var expr = Assert.IsType<ImportExpression>(stmt.Expression);
+        Assert.NotEqual(ImportPhase.None, expr.Phase);
+    }
+
+    [Theory]
+    [InlineData("import.source()")]
+    [InlineData("import.defer()")]
+    [InlineData("new import.source('mod')")]
+    [InlineData("new import.defer('mod')")]
+    [InlineData("import.source(...['mod'])")]
+    [InlineData("import.defer(...['mod'])")]
+    [InlineData("import.UNKNOWN('mod')")]
+    public void DynamicImportPhase_InvalidForms(string code)
+    {
+        var parser = CreateImportPhasesParser();
+        Assert.Throws<SyntaxErrorException>(() => parser.ParseScript(code));
+    }
+
+    [Fact]
+    public void SourcePhaseImport_NotEnabledWithoutFlag()
+    {
+        var parser = new Parser();
+        // Without the flag, `source` is just a binding name
+        var module = parser.ParseModule("import source from 'mod';");
+        var decl = Assert.IsType<ImportDeclaration>(Assert.Single(module.Body));
+        Assert.Equal(ImportPhase.None, decl.Phase);
+
+        // import.source is rejected without the flag
+        Assert.Throws<SyntaxErrorException>(() => parser.ParseScript("import.source('mod')"));
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Add parsing support for [source-phase-imports](https://github.com/tc39/proposal-source-phase-imports) (`import source x from "mod"`, `import.source(expr)`) behind `ExperimentalESFeatures.SourcePhaseImports`
- Add parsing support for [import-defer](https://github.com/tc39/proposal-defer-import-eval) (`import defer * as ns from "mod"`, `import.defer(expr)`) behind `ExperimentalESFeatures.ImportDefer`
- Add `ImportPhase` enum and `Phase` property to `ImportDeclaration` and `ImportExpression` AST nodes
- Remove `import-defer`, `source-phase-imports`, `json-modules`, and `import-assertions` from Test262 excluded features
- Update Test262 suite to latest (`2b2ecead6e`)

### Dynamic import argument rules

The two proposals have different grammars for their dynamic forms:

- **`import.defer()`** reuses `ImportCallArguments` and accepts 1 or 2 arguments (matching `import()`), per [tc39.es/proposal-defer-import-eval](https://tc39.es/proposal-defer-import-eval/)
- **`import.source()`** takes a single `AssignmentExpression` (exactly 1 argument), per [tc39.es/proposal-source-phase-imports](https://tc39.es/proposal-source-phase-imports/)

This distinction is reflected in `ParseDynamicImportPhase` which conditionally allows the optional second argument only for `import.defer()`.

## Test plan

- [x] All 12,530 main tests pass (including 31 new import-phase inline tests)
- [x] All 99,090 Test262 tests pass (latest suite, including ~770 newly-enabled import-related tests)
- [x] Source generator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)