### PR TITLE
Add ParserOptions.AllowDirectSuperOutsideMethod

### DIFF
--- a/src/Acornima/Parser.State.cs
+++ b/src/Acornima/Parser.State.cs
@@ -105,7 +105,10 @@ public partial class Parser
 
         _scopeId = 0;
         _scopeStack.Clear();
-        EnterScope(ScopeFlags.Top);
+        // NOTE: Seeding the root scope with the super flags (as opposed to just short-circuiting the `AllowDirectSuper` getter)
+        // makes the option follow the this binding: as `EnterScope` propagates the current this scope through arrow function scopes
+        // but not through ordinary function scopes, direct super calls are allowed exactly where the top level's this binding is in effect.
+        EnterScope(ScopeFlags.Top | (_options._allowDirectSuperOutsideMethod ? ScopeFlags.Super | ScopeFlags.DirectSuper : ScopeFlags.None));
 
         _privateNameStack.Clear();
 

--- a/src/Acornima/Parser.State.cs
+++ b/src/Acornima/Parser.State.cs
@@ -105,18 +105,15 @@ public partial class Parser
 
         _scopeId = 0;
         _scopeStack.Clear();
+
         // NOTE: Seeding the root scope with the super flags (as opposed to just short-circuiting the `AllowSuper`/`AllowDirectSuper` getters)
         // makes both options follow the this binding: as `EnterScope` propagates the current this scope through arrow function scopes
         // but not through ordinary function scopes, super is allowed exactly where the top level's this binding is in effect.
-        var superFlags = ScopeFlags.None;
-        if (_options._allowDirectSuperOutsideMethod)
-        {
-            superFlags = ScopeFlags.Super | ScopeFlags.DirectSuper;
-        }
-        else if (_options._allowSuperOutsideMethod)
-        {
-            superFlags = ScopeFlags.Super;
-        }
+        var superFlags =
+            _options._allowSuperCallOutsideConstructor ? ScopeFlags.Super | ScopeFlags.DirectSuper
+            : _options._allowSuperOutsideMethod ? ScopeFlags.Super
+            : ScopeFlags.None;
+
         EnterScope(ScopeFlags.Top | superFlags);
 
         _privateNameStack.Clear();

--- a/src/Acornima/Parser.State.cs
+++ b/src/Acornima/Parser.State.cs
@@ -105,10 +105,19 @@ public partial class Parser
 
         _scopeId = 0;
         _scopeStack.Clear();
-        // NOTE: Seeding the root scope with the super flags (as opposed to just short-circuiting the `AllowDirectSuper` getter)
-        // makes the option follow the this binding: as `EnterScope` propagates the current this scope through arrow function scopes
-        // but not through ordinary function scopes, direct super calls are allowed exactly where the top level's this binding is in effect.
-        EnterScope(ScopeFlags.Top | (_options._allowDirectSuperOutsideMethod ? ScopeFlags.Super | ScopeFlags.DirectSuper : ScopeFlags.None));
+        // NOTE: Seeding the root scope with the super flags (as opposed to just short-circuiting the `AllowSuper`/`AllowDirectSuper` getters)
+        // makes both options follow the this binding: as `EnterScope` propagates the current this scope through arrow function scopes
+        // but not through ordinary function scopes, super is allowed exactly where the top level's this binding is in effect.
+        var superFlags = ScopeFlags.None;
+        if (_options._allowDirectSuperOutsideMethod)
+        {
+            superFlags = ScopeFlags.Super | ScopeFlags.DirectSuper;
+        }
+        else if (_options._allowSuperOutsideMethod)
+        {
+            superFlags = ScopeFlags.Super;
+        }
+        EnterScope(ScopeFlags.Top | superFlags);
 
         _privateNameStack.Clear();
 
@@ -288,7 +297,7 @@ public partial class Parser
         // https://github.com/acornjs/acorn/blob/8.11.3/acorn/src/state.js > `get allowSuper`
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _options._allowSuperOutsideMethod || (CurrentThisScope._flags & (ScopeFlags.Super | ScopeFlags.InClassFieldInit)) != 0;
+        get => (CurrentThisScope._flags & (ScopeFlags.Super | ScopeFlags.InClassFieldInit)) != 0;
     }
 
     private bool AllowDirectSuper

--- a/src/Acornima/ParserOptions.cs
+++ b/src/Acornima/ParserOptions.cs
@@ -40,6 +40,7 @@ public record class ParserOptions
         _allowAwaitOutsideFunction = original._allowAwaitOutsideFunction;
         _allowNewTargetOutsideFunction = original._allowNewTargetOutsideFunction;
         _allowSuperOutsideMethod = original._allowSuperOutsideMethod;
+        _allowDirectSuperOutsideMethod = original._allowDirectSuperOutsideMethod;
         _checkPrivateFields = original._checkPrivateFields;
         _onInsertedSemicolon = original._onInsertedSemicolon;
         _onTrailingComma = original._onTrailingComma;
@@ -127,6 +128,20 @@ public record class ParserOptions
     /// Defaults to <see langword="false"/>.
     /// </summary>
     public bool AllowSuperOutsideMethod { get => _allowSuperOutsideMethod; init => _allowSuperOutsideMethod = value; }
+
+    internal readonly bool _allowDirectSuperOutsideMethod;
+    /// <summary>
+    /// Gets or sets whether to allow super calls to appear outside the constructor of a derived class.
+    /// Defaults to <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// This option is intended for parsing code which is evaluated in the context of the constructor of a derived class
+    /// (see <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> and its <c>inDerivedConstructor</c> parameter).
+    /// Enabling it means that direct super calls (as well as super property accesses) are permitted at the top level
+    /// of the parsed unit, that is, in the same places where <c>this</c> refers to the top level's this binding.
+    /// (E.g. they are allowed in arrow functions declared at the top level but not in ordinary functions.)
+    /// </remarks>
+    public bool AllowDirectSuperOutsideMethod { get => _allowDirectSuperOutsideMethod; init => _allowDirectSuperOutsideMethod = value; }
 
     internal readonly bool _allowTopLevelUsing;
     /// <summary>

--- a/src/Acornima/ParserOptions.cs
+++ b/src/Acornima/ParserOptions.cs
@@ -124,9 +124,17 @@ public record class ParserOptions
 
     internal readonly bool _allowSuperOutsideMethod;
     /// <summary>
-    /// Gets or sets whether to allow super identifiers to appear outside methods.
+    /// Gets or sets whether to allow super property accesses to appear outside methods.
     /// Defaults to <see langword="false"/>.
     /// </summary>
+    /// <remarks>
+    /// This option is intended for parsing code which is evaluated in the context of a method
+    /// (see <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> and its <c>inMethod</c> parameter).
+    /// Enabling it means that super property accesses are permitted at the top level of the parsed unit, that is,
+    /// in the same places where <c>this</c> refers to the top level's this binding.
+    /// (E.g. they are allowed in arrow functions declared at the top level but not in ordinary functions.)
+    /// Direct super calls remain disallowed; see <see cref="AllowDirectSuperOutsideMethod"/> for those.
+    /// </remarks>
     public bool AllowSuperOutsideMethod { get => _allowSuperOutsideMethod; init => _allowSuperOutsideMethod = value; }
 
     internal readonly bool _allowDirectSuperOutsideMethod;
@@ -140,6 +148,7 @@ public record class ParserOptions
     /// Enabling it means that direct super calls (as well as super property accesses) are permitted at the top level
     /// of the parsed unit, that is, in the same places where <c>this</c> refers to the top level's this binding.
     /// (E.g. they are allowed in arrow functions declared at the top level but not in ordinary functions.)
+    /// This option implies <see cref="AllowSuperOutsideMethod"/>.
     /// </remarks>
     public bool AllowDirectSuperOutsideMethod { get => _allowDirectSuperOutsideMethod; init => _allowDirectSuperOutsideMethod = value; }
 

--- a/src/Acornima/ParserOptions.cs
+++ b/src/Acornima/ParserOptions.cs
@@ -40,7 +40,7 @@ public record class ParserOptions
         _allowAwaitOutsideFunction = original._allowAwaitOutsideFunction;
         _allowNewTargetOutsideFunction = original._allowNewTargetOutsideFunction;
         _allowSuperOutsideMethod = original._allowSuperOutsideMethod;
-        _allowDirectSuperOutsideMethod = original._allowDirectSuperOutsideMethod;
+        _allowSuperCallOutsideConstructor = original._allowSuperCallOutsideConstructor;
         _checkPrivateFields = original._checkPrivateFields;
         _onInsertedSemicolon = original._onInsertedSemicolon;
         _onTrailingComma = original._onTrailingComma;
@@ -120,6 +120,11 @@ public record class ParserOptions
     /// Gets or sets whether to allow new.target meta-properties in the top-level scope.
     /// Defaults to <see langword="false"/>.
     /// </summary>
+    /// <remarks>
+    /// This option is intended for parsing code which is evaluated in the context of a function
+    /// (see <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> and its <c>inFunc</c> parameter).
+    /// Enabling it means that <c>new.target</c> accesses are permitted at the top level of the parsed code.
+    /// </remarks>
     public bool AllowNewTargetOutsideFunction { get => _allowNewTargetOutsideFunction; init => _allowNewTargetOutsideFunction = value; }
 
     internal readonly bool _allowSuperOutsideMethod;
@@ -130,14 +135,14 @@ public record class ParserOptions
     /// <remarks>
     /// This option is intended for parsing code which is evaluated in the context of a method
     /// (see <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> and its <c>inMethod</c> parameter).
-    /// Enabling it means that super property accesses are permitted at the top level of the parsed unit, that is,
+    /// Enabling it means that super property accesses are permitted at the top level of the parsed code, that is,
     /// in the same places where <c>this</c> refers to the top level's this binding.
     /// (E.g. they are allowed in arrow functions declared at the top level but not in ordinary functions.)
-    /// Direct super calls remain disallowed; see <see cref="AllowDirectSuperOutsideMethod"/> for those.
+    /// Direct super calls remain disallowed; see <see cref="AllowSuperCallOutsideConstructor"/> for those.
     /// </remarks>
     public bool AllowSuperOutsideMethod { get => _allowSuperOutsideMethod; init => _allowSuperOutsideMethod = value; }
 
-    internal readonly bool _allowDirectSuperOutsideMethod;
+    internal readonly bool _allowSuperCallOutsideConstructor;
     /// <summary>
     /// Gets or sets whether to allow super calls to appear outside the constructor of a derived class.
     /// Defaults to <see langword="false"/>.
@@ -146,11 +151,11 @@ public record class ParserOptions
     /// This option is intended for parsing code which is evaluated in the context of the constructor of a derived class
     /// (see <see href="https://tc39.es/ecma262/#sec-performeval">PerformEval</see> and its <c>inDerivedConstructor</c> parameter).
     /// Enabling it means that direct super calls (as well as super property accesses) are permitted at the top level
-    /// of the parsed unit, that is, in the same places where <c>this</c> refers to the top level's this binding.
+    /// of the parsed code, that is, in the same places where <c>this</c> refers to the top level's this binding.
     /// (E.g. they are allowed in arrow functions declared at the top level but not in ordinary functions.)
     /// This option implies <see cref="AllowSuperOutsideMethod"/>.
     /// </remarks>
-    public bool AllowDirectSuperOutsideMethod { get => _allowDirectSuperOutsideMethod; init => _allowDirectSuperOutsideMethod = value; }
+    public bool AllowSuperCallOutsideConstructor { get => _allowSuperCallOutsideConstructor; init => _allowSuperCallOutsideConstructor = value; }
 
     internal readonly bool _allowTopLevelUsing;
     /// <summary>

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -984,6 +984,95 @@ public partial class ParserTests
     }
 
     [Theory]
+    // Direct super calls are not allowed at the top level unless AllowDirectSuperOutsideMethod is enabled.
+    // (AllowSuperOutsideMethod alone doesn't enable them.)
+    [InlineData("script", "super()", false, false, "'super' keyword unexpected here")]
+    [InlineData("script", "super()", true, false, "'super' keyword unexpected here")]
+    [InlineData("script", "super()", false, true, null)]
+    [InlineData("script", "super()", true, true, null)]
+    [InlineData("module", "super()", false, false, "'super' keyword unexpected here")]
+    [InlineData("module", "super()", false, true, null)]
+    [InlineData("expression", "super()", false, false, "'super' keyword unexpected here")]
+    [InlineData("expression", "super()", false, true, null)]
+
+    // Arrow functions inherit the this binding of the top level, so direct super calls are allowed in them as well.
+    [InlineData("script", "(() => super())()", false, false, "'super' keyword unexpected here")]
+    [InlineData("script", "(() => super())()", false, true, null)]
+    [InlineData("script", "() => () => super()", false, true, null)]
+    [InlineData("script", "async () => super()", false, true, null)]
+    // (The argument of the nested eval call is just a string literal to the parser. When the host parses that string,
+    // the top level cases above apply to it.)
+    [InlineData("script", "(() => eval('super()'))()", false, false, null)]
+    [InlineData("script", "(() => eval('super()'))()", false, true, null)]
+
+    // Ordinary functions introduce a this binding of their own, so direct super calls remain disallowed in them.
+    [InlineData("script", "function f() { super() }", false, true, "'super' keyword unexpected here")]
+    [InlineData("script", "function f() { super() }", true, true, "'super' keyword unexpected here")]
+    [InlineData("script", "(function () { super() })", false, true, "'super' keyword unexpected here")]
+    [InlineData("script", "() => function () { super() }", false, true, "'super' keyword unexpected here")]
+    [InlineData("script", "({ m() { super() } })", false, true, "'super' keyword unexpected here")]
+
+    // Super property accesses are allowed wherever direct super calls are.
+    [InlineData("script", "super.x", false, false, "'super' keyword unexpected here")]
+    [InlineData("script", "super.x", true, false, null)]
+    [InlineData("script", "super.x", false, true, null)]
+    [InlineData("script", "(() => super.x)()", false, true, null)]
+    [InlineData("script", "function f() { super.x }", false, true, "'super' keyword unexpected here")]
+    // (AllowSuperOutsideMethod is unaffected by AllowDirectSuperOutsideMethod, including that it allows
+    // super property accesses in nested functions as well.)
+    [InlineData("script", "function f() { super.x }", true, false, null)]
+    [InlineData("script", "function f() { super.x }", true, true, null)]
+
+    // Classes are unaffected: the constructor of a derived class remains the only place where direct super calls are allowed.
+    [InlineData("script", "class A extends B { constructor() { super() } }", false, false, null)]
+    [InlineData("script", "class A extends B { constructor() { super() } }", false, true, null)]
+    [InlineData("script", "class A { constructor() { super() } }", false, false, "'super' keyword unexpected here")]
+    [InlineData("script", "class A { constructor() { super() } }", false, true, "'super' keyword unexpected here")]
+    [InlineData("script", "class A extends B { m() { super() } }", false, true, "'super' keyword unexpected here")]
+    [InlineData("script", "class A extends B { constructor() { function f() { super() } } }", false, true, "'super' keyword unexpected here")]
+    [InlineData("script", "class C { x = super.y }", false, false, null)]
+    [InlineData("script", "class C { x = super.y }", false, true, null)]
+    // (Class field initializers don't introduce a this binding of their own. This is why a direct super call is accepted
+    // in a field initializer of a class declared in the constructor of a derived class - and, with the option enabled,
+    // in a field initializer of a class declared at the top level as well.)
+    [InlineData("script", "class A extends B { constructor() { class C { x = super() } } }", false, false, null)]
+    [InlineData("script", "class C { x = super() }", false, false, "'super' keyword unexpected here")]
+    [InlineData("script", "class C { x = super() }", false, true, null)]
+    public void ShouldHandleDirectSuperOutsideMethod(string sourceType, string input, bool allowSuperOutsideMethod, bool allowDirectSuperOutsideMethod, string? expectedError)
+    {
+        var parser = new Parser(new ParserOptions
+        {
+            AllowSuperOutsideMethod = allowSuperOutsideMethod,
+            AllowDirectSuperOutsideMethod = allowDirectSuperOutsideMethod,
+        });
+        var parseAction = GetParseActionFor(sourceType);
+
+        if (expectedError is null)
+        {
+            Assert.NotNull(parseAction(parser, input));
+        }
+        else
+        {
+            var ex = Assert.Throws<SyntaxErrorException>(() => parseAction(parser, input));
+            Assert.Equal(expectedError, ex.Description);
+        }
+    }
+
+    [Fact]
+    public void AllowDirectSuperOutsideMethodShouldDefaultToFalse()
+    {
+        Assert.False(new ParserOptions().AllowDirectSuperOutsideMethod);
+        Assert.False(ParserOptions.Default.AllowDirectSuperOutsideMethod);
+
+        var options = ParserOptions.Default with { AllowDirectSuperOutsideMethod = true };
+        Assert.True(options.AllowDirectSuperOutsideMethod);
+        Assert.False(ParserOptions.Default.AllowDirectSuperOutsideMethod);
+
+        // The option must survive further copies of the options object.
+        Assert.True((options with { EcmaVersion = EcmaVersion.ES2022 }).AllowDirectSuperOutsideMethod);
+    }
+
+    [Theory]
     [InlineData("script", "(class { x = await })", EcmaVersion.Latest, null)]
     [InlineData("module", "(class { x = await })", EcmaVersion.Latest, "Unexpected reserved word")]
     [InlineData("script", "(class { x = await 1 })", EcmaVersion.Latest, "await is only valid in async functions and the top level bodies of modules")]

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -1012,16 +1012,20 @@ public partial class ParserTests
     [InlineData("script", "() => function () { super() }", false, true, "'super' keyword unexpected here")]
     [InlineData("script", "({ m() { super() } })", false, true, "'super' keyword unexpected here")]
 
-    // Super property accesses are allowed wherever direct super calls are.
+    // Super property accesses are allowed wherever direct super calls are, and AllowSuperOutsideMethod allows
+    // exactly those, without allowing direct super calls.
     [InlineData("script", "super.x", false, false, "'super' keyword unexpected here")]
     [InlineData("script", "super.x", true, false, null)]
     [InlineData("script", "super.x", false, true, null)]
     [InlineData("script", "(() => super.x)()", false, true, null)]
+    [InlineData("script", "(() => super.x)()", true, false, null)]
+    // (Both options follow the top level's this binding, so neither of them reaches into an ordinary function.)
     [InlineData("script", "function f() { super.x }", false, true, "'super' keyword unexpected here")]
-    // (AllowSuperOutsideMethod is unaffected by AllowDirectSuperOutsideMethod, including that it allows
-    // super property accesses in nested functions as well.)
-    [InlineData("script", "function f() { super.x }", true, false, null)]
-    [InlineData("script", "function f() { super.x }", true, true, null)]
+    [InlineData("script", "function f() { super.x }", true, false, "'super' keyword unexpected here")]
+    [InlineData("script", "function f() { super.x }", true, true, "'super' keyword unexpected here")]
+    // (Methods bring a home object of their own, so they are unaffected by either option.)
+    [InlineData("script", "({ m() { super.x } })", false, false, null)]
+    [InlineData("script", "({ m() { super.x } })", true, false, null)]
 
     // Classes are unaffected: the constructor of a derived class remains the only place where direct super calls are allowed.
     [InlineData("script", "class A extends B { constructor() { super() } }", false, false, null)]
@@ -1032,12 +1036,17 @@ public partial class ParserTests
     [InlineData("script", "class A extends B { constructor() { function f() { super() } } }", false, true, "'super' keyword unexpected here")]
     [InlineData("script", "class C { x = super.y }", false, false, null)]
     [InlineData("script", "class C { x = super.y }", false, true, null)]
-    // (Class field initializers don't introduce a this binding of their own. This is why a direct super call is accepted
-    // in a field initializer of a class declared in the constructor of a derived class - and, with the option enabled,
-    // in a field initializer of a class declared at the top level as well.)
-    [InlineData("script", "class A extends B { constructor() { class C { x = super() } } }", false, false, null)]
+    // (Class field initializers don't introduce a this binding of their own, but they are never a place for a direct
+    // super call either: https://tc39.es/ecma262/#sec-class-definitions-static-semantics-early-errors makes it a
+    // Syntax Error if the Initializer Contains SuperCall. So neither the constructor of a derived class nor the
+    // option enables one there.)
+    [InlineData("script", "class A extends B { constructor() { class C { x = super() } } }", false, false, "'super' keyword unexpected here")]
     [InlineData("script", "class C { x = super() }", false, false, "'super' keyword unexpected here")]
-    [InlineData("script", "class C { x = super() }", false, true, null)]
+    [InlineData("script", "class C { x = super() }", false, true, "'super' keyword unexpected here")]
+    // (A computed class element name, on the other hand, is evaluated in the enclosing scope, so it inherits
+    // whatever that scope allows.)
+    [InlineData("script", "class C { [super()]() { } }", false, false, "'super' keyword unexpected here")]
+    [InlineData("script", "class C { [super()]() { } }", false, true, null)]
     public void ShouldHandleDirectSuperOutsideMethod(string sourceType, string input, bool allowSuperOutsideMethod, bool allowDirectSuperOutsideMethod, string? expectedError)
     {
         var parser = new Parser(new ParserOptions

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -1052,7 +1052,7 @@ public partial class ParserTests
         var parser = new Parser(new ParserOptions
         {
             AllowSuperOutsideMethod = allowSuperOutsideMethod,
-            AllowDirectSuperOutsideMethod = allowDirectSuperOutsideMethod,
+            AllowSuperCallOutsideConstructor = allowDirectSuperOutsideMethod,
         });
         var parseAction = GetParseActionFor(sourceType);
 
@@ -1070,15 +1070,15 @@ public partial class ParserTests
     [Fact]
     public void AllowDirectSuperOutsideMethodShouldDefaultToFalse()
     {
-        Assert.False(new ParserOptions().AllowDirectSuperOutsideMethod);
-        Assert.False(ParserOptions.Default.AllowDirectSuperOutsideMethod);
+        Assert.False(new ParserOptions().AllowSuperCallOutsideConstructor);
+        Assert.False(ParserOptions.Default.AllowSuperCallOutsideConstructor);
 
-        var options = ParserOptions.Default with { AllowDirectSuperOutsideMethod = true };
-        Assert.True(options.AllowDirectSuperOutsideMethod);
-        Assert.False(ParserOptions.Default.AllowDirectSuperOutsideMethod);
+        var options = ParserOptions.Default with { AllowSuperCallOutsideConstructor = true };
+        Assert.True(options.AllowSuperCallOutsideConstructor);
+        Assert.False(ParserOptions.Default.AllowSuperCallOutsideConstructor);
 
         // The option must survive further copies of the options object.
-        Assert.True((options with { EcmaVersion = EcmaVersion.ES2022 }).AllowDirectSuperOutsideMethod);
+        Assert.True((options with { EcmaVersion = EcmaVersion.ES2022 }).AllowSuperCallOutsideConstructor);
     }
 
     [Theory]

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -984,7 +984,7 @@ public partial class ParserTests
     }
 
     [Theory]
-    // Direct super calls are not allowed at the top level unless AllowDirectSuperOutsideMethod is enabled.
+    // Direct super calls are not allowed at the top level unless AllowSuperCallOutsideConstructor is enabled.
     // (AllowSuperOutsideMethod alone doesn't enable them.)
     [InlineData("script", "super()", false, false, "'super' keyword unexpected here")]
     [InlineData("script", "super()", true, false, "'super' keyword unexpected here")]
@@ -1047,12 +1047,12 @@ public partial class ParserTests
     // whatever that scope allows.)
     [InlineData("script", "class C { [super()]() { } }", false, false, "'super' keyword unexpected here")]
     [InlineData("script", "class C { [super()]() { } }", false, true, null)]
-    public void ShouldHandleDirectSuperOutsideMethod(string sourceType, string input, bool allowSuperOutsideMethod, bool allowDirectSuperOutsideMethod, string? expectedError)
+    public void ShouldHandleSuperCallOutsideConstructor(string sourceType, string input, bool allowSuperOutsideMethod, bool allowSuperCallOutsideConstructor, string? expectedError)
     {
         var parser = new Parser(new ParserOptions
         {
             AllowSuperOutsideMethod = allowSuperOutsideMethod,
-            AllowSuperCallOutsideConstructor = allowDirectSuperOutsideMethod,
+            AllowSuperCallOutsideConstructor = allowSuperCallOutsideConstructor,
         });
         var parseAction = GetParseActionFor(sourceType);
 
@@ -1068,7 +1068,7 @@ public partial class ParserTests
     }
 
     [Fact]
-    public void AllowDirectSuperOutsideMethodShouldDefaultToFalse()
+    public void AllowSuperCallOutsideConstructorShouldDefaultToFalse()
     {
         Assert.False(new ParserOptions().AllowSuperCallOutsideConstructor);
         Assert.False(ParserOptions.Default.AllowSuperCallOutsideConstructor);


### PR DESCRIPTION
> **Draft** — opening for review before it is proposed for merge.

### Motivation

ECMA-262's [PerformEval](https://tc39.es/ecma262/#sec-performeval) passes `inDerivedConstructor` into the parse of the eval code, so a direct eval called from the constructor of a derived class may legally contain a super call:

```js
class B { }
class D extends B { constructor() { eval("super()") } }
```

There is currently no way to ask the parser for that. `AllowSuperOutsideMethod` enables super *property accesses* only, and `AllowDirectSuper` is derived from the scope flags alone with no option behind it — unlike its siblings `AllowSuper` and `AllowNewDotTarget`. So an embedder that computes `inDerivedConstructor` correctly still cannot pass it on, and every `eval` containing a super call comes back as a `SyntaxError`.

This came up in [Jint](https://github.com/sebastienros/jint), which uses Acornima as its front end and already tracks `inDerivedConstructor` correctly where it parses eval code — the missing piece is purely the parser option. Three test262 conformance tests fail on this today (`staging/sm/class/derivedConstructorArrowEvalSuperCall.js`, `derivedConstructorArrowEvalNestedSuperCall.js`, `staging/sm/fields/bug1587574.js`).

### What this adds

`ParserOptions.AllowDirectSuperOutsideMethod` (default `false`), declared next to `AllowSuperOutsideMethod` and following the same pattern — backing field, `get`/`init`, copy-constructor entry.

### Design: seeding the root scope, not short-circuiting the getter

The obvious implementation — `AllowDirectSuper => _options._allowDirectSuperOutsideMethod || …` — would be wrong. It would allow

```js
function f() { super() }
```

at the top level of the parsed unit, which the spec does not: eval code in a derived constructor gets the constructor's this binding, and an ordinary function introduces one of its own.

Instead the option seeds the root scope with the flag pair `ParseMethod` already uses for a derived constructor:

```csharp
EnterScope(ScopeFlags.Top | (_options._allowDirectSuperOutsideMethod ? ScopeFlags.Super | ScopeFlags.DirectSuper : ScopeFlags.None));
```

Because `EnterScope` propagates the current this scope through arrow function scopes but not through ordinary function scopes, the spec semantics fall out of the existing machinery with no new logic:

| code | option on | option off |
| --- | --- | --- |
| `super()` | parses | `SyntaxError` |
| `(() => super())()` | parses | `SyntaxError` |
| `() => () => super()` | parses | `SyntaxError` |
| `function f() { super() }` | `SyntaxError` | `SyntaxError` |
| `(function () { super() })` | `SyntaxError` | `SyntaxError` |
| `({ m() { super() } })` | `SyntaxError` | `SyntaxError` |
| `class A extends B { m() { super() } }` | `SyntaxError` | `SyntaxError` |

`ScopeFlags.Super` is seeded alongside `DirectSuper` for two reasons: `AllowSuper` is checked first in `ParseExprAtom`, so `DirectSuper` alone would leave `super()` rejected; and a derived constructor is a method, so super property accesses are legal there anyway — which is exactly why `ParseMethod` sets the same pair.

`AllowSuperOutsideMethod` and `AllowNewTargetOutsideFunction` are deliberately untouched: with the new option disabled nothing changes at all.

### Tests

`ShouldHandleDirectSuperOutsideMethod` (37 cases, next to `ShouldHandleSuperKeywordEdgeCases` and in its style) covers both options in all four combinations across script/module/expression: the top-level and arrow cases, the ordinary-function and method cases that must keep failing, `super.x` under each option, and class bodies. `AllowDirectSuperOutsideMethodShouldDefaultToFalse` pins the default and that a `with`-expression copy keeps the flag.

Green: `Acornima.Tests` on net462/net8.0/net9.0/net10.0 (13,025–13,028 each), `Acornima.Tests.Test262` (99,090), `Acornima.Tests.SourceGenerators`, solution build with 0 warnings.

### Two things noticed while doing this, not fixed here

1. **`_allowTopLevelUsing` is missing from the `ParserOptions` copy constructor** — it is the only bool option that is, so `(ParserOptions.Default with { AllowTopLevelUsing = true }) with { EcmaVersion = … }` silently drops the flag. Happy to send that as its own one-line PR.
2. **A class body enters a non-var scope**, so a field initializer does not introduce a this binding. That is why `class A extends B { constructor() { class C { x = super() } } }` already parses on master (V8 rejects it), and consequently `class C { x = super() }` parses when this option is on. Same quirk, inherited from acorn — both rows are pinned in the new theory with a comment rather than changed.
