### PR TITLE
Pin NuGet.Frameworks forward so the Test target can evaluate projects

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -15,6 +15,21 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Components" Version="10.1.0" />
+
+    <!--
+      NUKE evaluates project files in-process (ITest asks each test project whether it references
+      GitHubActionsTestLogger), which runs the installed SDK's own targets inside this process. Those
+      targets bind NuGet.Frameworks by strong name, and .NET SDK 10.0.400 wants 7.9.0.0 where
+      Nuke.Components resolves 6.12.1 transitively through NuGet.Packaging. App-local assemblies win
+      over the resolver MSBuildLocator installs, so the older one shadows the SDK's copy and
+      [MSBuild]::GetTargetFrameworkIdentifier(net10.0) throws InvalidProjectFileException — a build
+      that compiles fine but cannot run a single test.
+
+      Pinning forward is safe in both directions: the runtime binds a higher assembly version than the
+      one requested, so an SDK still asking for 6.12.1 is satisfied too. Remove once NUKE ships a
+      NuGet.Packaging new enough to bring 7.9.0 in on its own.
+    -->
+    <PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
CI on `master` and on every pull request currently fails at `Test` on all three runners. Nothing in
the repository caused it — the hosted runner images moved to .NET SDK **10.0.400**.

```
Microsoft.Build.Exceptions.InvalidProjectFileException: The expression
"[MSBuild]::GetTargetFrameworkIdentifier(net10.0)" cannot be evaluated. Could not load file or
assembly 'NuGet.Frameworks, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
The located assembly's manifest definition does not match the assembly reference.
```

(from the [2026-08-16 `pr` run](https://github.com/adams85/acornima/actions/runs/31956845395), which
reports `Target "Test" has thrown an exception` on `macos-latest`)

## Why only `Test`

`Compile` and `Pack` shell out to the `dotnet` CLI, so they are unaffected and stayed green — which
is what makes this read as a test failure rather than a toolchain one.

`Test` is different. `ITest` asks each test project whether it references `GitHubActionsTestLogger`,
and that answer comes from evaluating the project **in-process**, which runs the installed SDK's own
targets inside the NUKE process. Those targets bind `NuGet.Frameworks` by strong name: SDK 10.0.400
wants `7.9.0.0`, while `Nuke.Components` 10.1.0 resolves `6.12.1` transitively through
`NuGet.Packaging`. An app-local assembly wins over the resolver `MSBuildLocator` installs, so the
older copy shadows the SDK's and every evaluation throws.

The workflows install `dotnet-version: 10.0` and there is no `global.json`, so CI takes whatever the
image ships. That is why this began without a commit.

## The change

One line in `build/_build.csproj` (plus a comment recording why), no source changes:

```xml
<PackageReference Include="NuGet.Frameworks" Version="7.9.0" />
```

Pinned **forward** rather than pinning the SDK back to a working feature band. The runtime binds a
*higher* assembly version than the one requested, so an SDK still asking for `6.12.1` is satisfied by
`7.9.0` too — this fixes 10.0.400 without dating the repository to one band or needing a `global.json`
that has to be revisited every SDK release. It is removable once NUKE ships a `NuGet.Packaging` new
enough to bring `7.9.0` in on its own.

If you would rather pin the SDK, that works too and is a smaller conceptual change — happy to switch
this PR to a `global.json` instead. Upstream NUKE's successor hit the identical problem and is taking
both routes: [Fallout-build/Fallout#638](https://github.com/Fallout-build/Fallout/issues/638), with
the `NuGet.Packaging` bump held for a major (NuGet 7.x drops `netstandard2.0`) and an SDK pin as the
stopgap. A consumer-side forward pin avoids both of those costs.

## Verification

- `./build.ps1 Test` locally on Windows with SDK 10.0.400: **112,079 passed, 0 failed**, unchanged
  from before the pin. Worth noting the Windows failure mode differs — the pre-fix run there survived
  with a `[WRN] : Exception was suppressed`, and that warning is gone after the pin, while Linux and
  macOS fail outright.
- The same fix is running green in CI on another `ITest`-based repository of mine on
  `ubuntu-latest` + SDK 10.0.400.
- The real check is this PR's own `pr` workflow across `ubuntu-latest`, `windows-latest` and
  `macos-latest` — I could not reproduce the hard failure locally, so please judge it on that.

Generated workflow files are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
