### PR TITLE
Fix CoverInitializedName early error not raised when the object literal is not refined into a pattern

### DIFF
--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -219,16 +219,17 @@ public partial class Parser
             Debug.Assert(op != Operator.Unknown);
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            Node ReinterpretAssignmentTarget(ref DestructuringErrors destructuringErrors, Expression left, Operator op)
+            Node ReinterpretAssignmentTarget(Node leftNode, Operator op, ref DestructuringErrors destructuringErrors, bool ownsDestructuringErrors)
             {
                 // This piece of code was extracted into a non-inlined method to increase maximum possible stack depth.
 
-                var leftNode = _tokenizer._type == TokenType.Eq
-                    ? ToAssignable(left, ref destructuringErrors, isBinding: false,
-                        isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.Assignment)
-                    : left;
+                if (_tokenizer._type == TokenType.Eq)
+                {
+                    leftNode = ToAssignable(leftNode, ref destructuringErrors, isBinding: false,
+                        isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.Assignment);
+                }
 
-                if (!IsNullRef(ref destructuringErrors))
+                if (!ownsDestructuringErrors)
                 {
                     destructuringErrors.ParenthesizedAssign = destructuringErrors.TrailingComma = -1;
                 }
@@ -252,7 +253,7 @@ public partial class Parser
                 return leftNode;
             }
 
-            Node leftNode = ReinterpretAssignmentTarget(ref actualDestructuringErrors, left, op);
+            Node leftNode = ReinterpretAssignmentTarget(left, op, ref actualDestructuringErrors, ownsDestructuringErrors);
 
             Next();
 
@@ -435,7 +436,10 @@ public partial class Parser
 
             EnterRecursion();
             var argument = ExitRecursion(ParseMaybeUnary(sawUnary: true, incDec: update, ref NullRef<DestructuringErrors>(), context));
-            CheckExpressionErrors(ref destructuringErrors, andThrow: true);
+
+            // Original acornjs implementation needs this check, however it can be skipped here as both double proto and
+            // shorthand initializer is checked eagerly in this implementation (see ParseObject and ParsePropertyValue).
+            // CheckExpressionErrors(ref destructuringErrors, andThrow: true);
 
             if (update)
             {
@@ -494,14 +498,10 @@ public partial class Parser
         else
         {
             expr = ParseExprSubscripts(ref destructuringErrors, context);
-
-            // Original acornjs implementation returns early if there is a shorthand assignment or double proto error.
-            // This is not consistent with V8 error reporting behavior, which checks for invalid left-hand side error
-            // also in these cases. Thus, we remove the early return.
-            //if (CheckExpressionErrors(ref destructuringErrors))
-            //{
-            //    return expr;
-            //}
+            if (CheckExpressionErrors(ref destructuringErrors))
+            {
+                return expr;
+            }
 
             while (_tokenizer._type.Postfix && !CanInsertSemicolon())
             {
@@ -1480,7 +1480,12 @@ public partial class Parser
         {
             if (!first)
             {
-                Expect(TokenType.Comma);
+                //Expect(TokenType.Comma); // original acornjs error reporting
+                if (!Eat(TokenType.Comma))
+                {
+                    CheckExpressionErrors(ref destructuringErrors, andThrow: true);
+                    Unexpected();
+                }
 
                 // We deviate a bit from the original acornjs implementation here to make trailing comma errors recoverable.
                 if (AfterTrailingComma(TokenType.BraceRight, allowTrailingComma))
@@ -1705,16 +1710,24 @@ public partial class Parser
             {
                 value = ParseMaybeDefault(startMarker, key);
             }
-            else if (_tokenizer._type == TokenType.Eq && !IsNullRef(ref destructuringErrors))
+            else if (_tokenizer._type == TokenType.Eq)
             {
+                // We deviate a bit from the original acornjs implementation here to bring error reporting behavior closer to V8.
+
+                Next();
+
+                var right = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
+
+                if (IsNullRef(ref destructuringErrors))
+                {
+                    Raise(_tokenizer._start, InvalidCoverInitializedName);
+                }
+
                 if (destructuringErrors.ShorthandAssign < 0)
                 {
                     destructuringErrors.ShorthandAssign = _tokenizer._start;
                 }
 
-                Next();
-
-                var right = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
                 value = FinishNode(startMarker, new AssignmentPattern(key, right));
             }
             else
@@ -1914,7 +1927,12 @@ public partial class Parser
         {
             if (!first)
             {
-                Expect(TokenType.Comma);
+                // Expect(TokenType.Comma); // original acornjs error reporting
+                if (!Eat(TokenType.Comma))
+                {
+                    CheckExpressionErrors(ref destructuringErrors, andThrow: true);
+                    Unexpected();
+                }
 
                 // We deviate a bit from the original acornjs implementation here to make trailing comma errors recoverable.
                 if (AfterTrailingComma(close, allowTrailingComma))

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -1714,6 +1714,8 @@ public partial class Parser
             {
                 // We deviate a bit from the original acornjs implementation here to bring error reporting behavior closer to V8.
 
+                var assignPosition = _tokenizer._start;
+
                 Next();
 
                 var right = ParseMaybeAssign(ref NullRef<DestructuringErrors>());
@@ -1725,7 +1727,7 @@ public partial class Parser
 
                 if (destructuringErrors.ShorthandAssign < 0)
                 {
-                    destructuringErrors.ShorthandAssign = _tokenizer._start;
+                    destructuringErrors.ShorthandAssign = assignPosition;
                 }
 
                 value = FinishNode(startMarker, new AssignmentPattern(key, right));

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -181,7 +181,7 @@ public partial class Parser
             _tokenizer._expressionAllowed = false;
         }
 
-        int oldParenAssign, oldTrailingComma, oldDoubleProto;
+        int oldParenAssign, oldTrailingComma;
 
         DestructuringErrors ownDestructuringErrors;
         SkipInit(out ownDestructuringErrors);
@@ -193,7 +193,6 @@ public partial class Parser
 
             SkipInit(out oldParenAssign);
             SkipInit(out oldTrailingComma);
-            SkipInit(out oldDoubleProto);
         }
         else
         {
@@ -201,7 +200,6 @@ public partial class Parser
 
             oldParenAssign = actualDestructuringErrors.ParenthesizedAssign;
             oldTrailingComma = actualDestructuringErrors.TrailingComma;
-            oldDoubleProto = actualDestructuringErrors.DoubleProto;
 
             actualDestructuringErrors.ParenthesizedAssign = actualDestructuringErrors.TrailingComma = -1;
         }
@@ -232,13 +230,8 @@ public partial class Parser
 
                 if (!IsNullRef(ref destructuringErrors))
                 {
-                    destructuringErrors.ParenthesizedAssign = destructuringErrors.TrailingComma = destructuringErrors.DoubleProto = -1;
+                    destructuringErrors.ParenthesizedAssign = destructuringErrors.TrailingComma = -1;
                 }
-
-                // NOTE: The recorded shorthand property assignment error can only be discarded when the shorthand default was
-                // actually used correctly, that is, when the conversion refined the object literal containing it into an
-                // object pattern (see also ConsumeCoverInitializedNameError).
-                var coverInitializedNamePosition = ConsumeCoverInitializedNameError(ref destructuringErrors, leftNode);
 
                 if (_tokenizer._type == TokenType.Eq)
                 {
@@ -254,11 +247,7 @@ public partial class Parser
                         lhsKind: LeftHandSideKind.Assignment);
                 }
 
-                // NOTE: An invalid left-hand side is reported first (as V8 does so in most of the cases as well).
-                if (coverInitializedNamePosition >= 0)
-                {
-                    Raise(coverInitializedNamePosition, InvalidCoverInitializedName);
-                }
+                CheckAssignmentLhsErrors(leftNode, ref destructuringErrors);
 
                 return leftNode;
             }
@@ -268,11 +257,6 @@ public partial class Parser
             Next();
 
             var right = ParseMaybeAssign(ref NullRef<DestructuringErrors>(), context);
-
-            if (!ownsDestructuringErrors && oldDoubleProto >= 0)
-            {
-                actualDestructuringErrors.DoubleProto = oldDoubleProto;
-            }
 
             return ExitRecursion(FinishNode(startMarker, new AssignmentExpression(op, leftNode, right)));
         }

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -235,10 +235,10 @@ public partial class Parser
                     destructuringErrors.ParenthesizedAssign = destructuringErrors.TrailingComma = destructuringErrors.DoubleProto = -1;
                 }
 
-                if (destructuringErrors.ShorthandAssign >= leftNode.Start)
-                {
-                    destructuringErrors.ShorthandAssign = -1; // reset because shorthand default was used correctly
-                }
+                // NOTE: The recorded shorthand property assignment error can only be discarded when the shorthand default was
+                // actually used correctly, that is, when the conversion refined the object literal containing it into an
+                // object pattern (see also ConsumeCoverInitializedNameError).
+                var coverInitializedNamePosition = ConsumeCoverInitializedNameError(ref destructuringErrors, leftNode);
 
                 if (_tokenizer._type == TokenType.Eq)
                 {
@@ -252,6 +252,12 @@ public partial class Parser
                         isInPattern: destructuringErrors.IsInPattern,
                         allowCall: !_strict && op is not (Operator.LogicalAndAssignment or Operator.LogicalOrAssignment or Operator.NullishCoalescingAssignment),
                         lhsKind: LeftHandSideKind.Assignment);
+                }
+
+                // NOTE: An invalid left-hand side is reported first (as V8 does so in most of the cases as well).
+                if (coverInitializedNamePosition >= 0)
+                {
+                    Raise(coverInitializedNamePosition, InvalidCoverInitializedName);
                 }
 
                 return leftNode;

--- a/src/Acornima/Parser.Expression.cs
+++ b/src/Acornima/Parser.Expression.cs
@@ -1722,7 +1722,7 @@ public partial class Parser
 
                 if (IsNullRef(ref destructuringErrors))
                 {
-                    Raise(_tokenizer._start, InvalidCoverInitializedName);
+                    Raise(assignPosition, InvalidCoverInitializedName);
                 }
 
                 if (destructuringErrors.ShorthandAssign < 0)

--- a/src/Acornima/Parser.ParseUtil.cs
+++ b/src/Acornima/Parser.ParseUtil.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Acornima.Ast;
-using Acornima.Helpers;
 
 namespace Acornima;
 
@@ -304,90 +302,95 @@ public partial class Parser
             return destructuringErrors.ShorthandAssign >= 0 || destructuringErrors.DoubleProto >= 0;
         }
 
-        if (destructuringErrors.ShorthandAssign >= 0)
-        {
-            // Raise(destructuringErrors.ShorthandAssign, "Shorthand property assignments are valid only in destructuring patterns"); // original acornjs error reporting
-            Raise(destructuringErrors.ShorthandAssign, InvalidCoverInitializedName);
-        }
+        var hasShorthandAssign = destructuringErrors.ShorthandAssign >= 0;
+        var hasDoubleProto = destructuringErrors.DoubleProto >= 0;
 
-        if (destructuringErrors.DoubleProto >= 0)
+        if (hasShorthandAssign || hasDoubleProto)
         {
-            // RaiseRecoverable(destructuringErrors.DoubleProto, "Redefinition of __proto__ property"); // original acornjs error reporting
-            Raise(destructuringErrors.DoubleProto, DuplicateProto);
+            if (hasShorthandAssign && (!hasDoubleProto || destructuringErrors.ShorthandAssign < destructuringErrors.DoubleProto))
+            {
+                // Raise(destructuringErrors.ShorthandAssign, "Shorthand property assignments are valid only in destructuring patterns"); // original acornjs error reporting
+                Raise(destructuringErrors.ShorthandAssign, InvalidCoverInitializedName);
+            }
+            else
+            {
+                // RaiseRecoverable(destructuringErrors.DoubleProto, "Redefinition of __proto__ property"); // original acornjs error reporting
+                Raise(destructuringErrors.DoubleProto, DuplicateProto);
+            }
         }
 
         return false;
     }
 
-    /// <summary>
-    /// Discards the recorded CoverInitializedName error (if there is one within <paramref name="convertedNode"/>) and returns
-    /// the position to report it at when it turns out that the conversion of <paramref name="convertedNode"/> to an assignment
-    /// target didn't resolve it (otherwise returns <c>-1</c>).
-    /// </summary>
-    /// <remarks>
-    /// A shorthand property assignment (CoverInitializedName, e.g. <c>{a = 0}</c>) is only valid when the object literal
-    /// containing it is refined into an object assignment pattern
-    /// (see https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors, Note 2).
-    /// Converting a left-hand side expression to an assignment target doesn't necessarily refine such an object literal:
-    /// e.g. in <c>[{a = 0}.x] = []</c> the destructuring assignment target is the member expression <c>{a = 0}.x</c>, which
-    /// is a valid assignment target on its own, so <c>{a = 0}</c> remains an actual object literal, for which the early error
-    /// applies. (The original acornjs implementation discards the recorded error based on its position only, which makes it
-    /// miss all such cases. See also https://github.com/adams85/acornima/issues/46)
-    /// </remarks>
-    private static int ConsumeCoverInitializedNameError(ref DestructuringErrors destructuringErrors, Node convertedNode)
+    private void CheckAssignmentLhsErrors(Node convertedNode, ref DestructuringErrors destructuringErrors)
     {
-        Debug.Assert(!Unsafe.IsNullRef(ref destructuringErrors));
+        // Duplicate __proto__ properties (e.g. `{__proto__: x, __proto__: x}`) or shorthand property assignment (e.g. `{a = 0}`)
+        // are only valid when the object literal containing it is refined into an object assignment pattern
+        // (see https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors, Note 2).
+        // Converting a left-hand side expression to an assignment target doesn't necessarily refine such an object literal:
+        // e.g. in `[{a = 0}.x] = []` the destructuring assignment target is the member expression `{a = 0}.x`, which
+        // is a valid assignment target on its own, so `{a = 0}` remains an actual object literal, for which the early error
+        // applies. (The original acornjs implementation discards the recorded error based on its position only, which makes it
+        // miss all such cases. See also https://github.com/adams85/acornima/issues/46)
 
-        // As shorthand property assignments are recorded in source order and only the first one is kept, a recorded
-        // position which is not before the start of the converted node is necessarily within it.
-        if (destructuringErrors.ShorthandAssign < convertedNode.Start)
+        // As duplicate __proto__ and shorthand property assignments are recorded in source order and only the first occurrence
+        // of each is kept, a recorded position which is not before the start of the converted node is necessarily within it.
+
+        // NOTE: The reported position is the position of the first duplicate __proto__ or shorthand property assignment,
+        // which, in the rare case of multiple ones (e.g. `[{a = 0}, {b = 0}.x] = []`), is not necessarily the position of the
+        // one which remained unrefined. (V8 reports the position of the first one in such cases as well.)
+
+        var hasShorthandAssign = destructuringErrors.ShorthandAssign >= convertedNode.Start;
+        var hasDoubleProto = destructuringErrors.DoubleProto >= convertedNode.Start;
+
+        if (hasShorthandAssign || hasDoubleProto)
         {
-            return -1;
+            // The recorded error(s) can only be discarded when the duplicate __proto__ and/or shorthand property assignment were
+            // actually used correctly, that is, when the conversion refined the object literal containing them into an object pattern.
+
+            CheckForErrors(convertedNode, hasShorthandAssign, hasDoubleProto);
+
+            if (hasShorthandAssign)
+            {
+                destructuringErrors.ShorthandAssign = -1;
+            }
+
+            if (hasDoubleProto)
+            {
+                destructuringErrors.DoubleProto = -1;
+            }
         }
 
-        // NOTE: The reported position is the position of the first shorthand property assignment, which, in the rare case
-        // of multiple ones (e.g. `[{a = 0}, {b = 0}.x] = []`), is not necessarily the position of the one which remained
-        // unrefined. (V8 reports the position of the first one in such cases as well.)
-        var position = destructuringErrors.ShorthandAssign;
-        destructuringErrors.ShorthandAssign = -1;
-
-        return ContainsCoverInitializedName(convertedNode) ? position : -1;
-    }
-
-    private static bool ContainsCoverInitializedName(Node node)
-    {
-        // NOTE: This search is only done when a CoverInitializedName error is recorded within the converted node, that is,
-        // on a code path which either reports an error or parses a destructuring assignment which makes use of the rarely
-        // used shorthand property assignment syntax. So it doesn't add any cost to the common code paths.
-
-        var stack = new ArrayList<Node>();
-
-        for (; ; )
+        void CheckForErrors(Node node, bool hasShorthandAssign, bool hasDoubleProto)
         {
-            if (node.Type == NodeType.ObjectExpression)
+            var sawProto = false;
+
+            foreach (var child in node.ChildNodes)
             {
-                foreach (var property in node.As<ObjectExpression>().Properties)
+                if (child.Type == NodeType.Property && child is ObjectProperty property)
                 {
-                    // In an object literal, a shorthand property whose value is an assignment pattern can only originate from
-                    // a CoverInitializedName. (In object patterns, properties are represented by AssignmentProperty nodes.)
-                    if (property is ObjectProperty { Shorthand: true, Value.Type: NodeType.AssignmentPattern })
+                    if (hasShorthandAssign
+                        && property is { Shorthand: true, Value.Type: NodeType.AssignmentPattern })
                     {
-                        return true;
+                        _tokenizer.RaiseAtNext(property.Value.As<AssignmentPattern>().Left.End, InvalidCoverInitializedName);
+                    }
+
+                    if (hasDoubleProto
+                        // These conditions must be in sync with CheckPropertyClash.
+                        && property is { Kind: PropertyKind.Init, Computed: false, Method: false, Shorthand: false }
+                        && CheckKeyName(property.Key, computed: false, "__proto__"))
+                    {
+                        if (sawProto)
+                        {
+                            Raise(property.Start, DuplicateProto);
+                        }
+
+                        sawProto = true;
                     }
                 }
-            }
 
-            foreach (var childNode in node.ChildNodes)
-            {
-                stack.Push(childNode);
+                CheckForErrors(child, hasShorthandAssign, hasDoubleProto);
             }
-
-            if (stack.Count == 0)
-            {
-                return false;
-            }
-
-            node = stack.Pop();
         }
     }
 

--- a/src/Acornima/Parser.ParseUtil.cs
+++ b/src/Acornima/Parser.ParseUtil.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Acornima.Ast;
+using Acornima.Helpers;
 
 namespace Acornima;
 
@@ -315,6 +317,78 @@ public partial class Parser
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Discards the recorded CoverInitializedName error (if there is one within <paramref name="convertedNode"/>) and returns
+    /// the position to report it at when it turns out that the conversion of <paramref name="convertedNode"/> to an assignment
+    /// target didn't resolve it (otherwise returns <c>-1</c>).
+    /// </summary>
+    /// <remarks>
+    /// A shorthand property assignment (CoverInitializedName, e.g. <c>{a = 0}</c>) is only valid when the object literal
+    /// containing it is refined into an object assignment pattern
+    /// (see https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors, Note 2).
+    /// Converting a left-hand side expression to an assignment target doesn't necessarily refine such an object literal:
+    /// e.g. in <c>[{a = 0}.x] = []</c> the destructuring assignment target is the member expression <c>{a = 0}.x</c>, which
+    /// is a valid assignment target on its own, so <c>{a = 0}</c> remains an actual object literal, for which the early error
+    /// applies. (The original acornjs implementation discards the recorded error based on its position only, which makes it
+    /// miss all such cases. See also https://github.com/adams85/acornima/issues/46)
+    /// </remarks>
+    private static int ConsumeCoverInitializedNameError(ref DestructuringErrors destructuringErrors, Node convertedNode)
+    {
+        Debug.Assert(!Unsafe.IsNullRef(ref destructuringErrors));
+
+        // As shorthand property assignments are recorded in source order and only the first one is kept, a recorded
+        // position which is not before the start of the converted node is necessarily within it.
+        if (destructuringErrors.ShorthandAssign < convertedNode.Start)
+        {
+            return -1;
+        }
+
+        // NOTE: The reported position is the position of the first shorthand property assignment, which, in the rare case
+        // of multiple ones (e.g. `[{a = 0}, {b = 0}.x] = []`), is not necessarily the position of the one which remained
+        // unrefined. (V8 reports the position of the first one in such cases as well.)
+        var position = destructuringErrors.ShorthandAssign;
+        destructuringErrors.ShorthandAssign = -1;
+
+        return ContainsCoverInitializedName(convertedNode) ? position : -1;
+    }
+
+    private static bool ContainsCoverInitializedName(Node node)
+    {
+        // NOTE: This search is only done when a CoverInitializedName error is recorded within the converted node, that is,
+        // on a code path which either reports an error or parses a destructuring assignment which makes use of the rarely
+        // used shorthand property assignment syntax. So it doesn't add any cost to the common code paths.
+
+        var stack = new ArrayList<Node>();
+
+        for (; ; )
+        {
+            if (node.Type == NodeType.ObjectExpression)
+            {
+                foreach (var property in node.As<ObjectExpression>().Properties)
+                {
+                    // In an object literal, a shorthand property whose value is an assignment pattern can only originate from
+                    // a CoverInitializedName. (In object patterns, properties are represented by AssignmentProperty nodes.)
+                    if (property is ObjectProperty { Shorthand: true, Value.Type: NodeType.AssignmentPattern })
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            foreach (var childNode in node.ChildNodes)
+            {
+                stack.Push(childNode);
+            }
+
+            if (stack.Count == 0)
+            {
+                return false;
+            }
+
+            node = stack.Pop();
+        }
     }
 
     private void CheckYieldAwaitInDefaultParams()

--- a/src/Acornima/Parser.ParseUtil.cs
+++ b/src/Acornima/Parser.ParseUtil.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Acornima.Ast;
+using Acornima.Helpers;
 
 namespace Acornima;
 
@@ -297,29 +299,46 @@ public partial class Parser
             return false;
         }
 
+        var hasError = destructuringErrors.ShorthandAssign >= 0 || destructuringErrors.DoubleProto >= 0;
+
         if (!andThrow)
         {
-            return destructuringErrors.ShorthandAssign >= 0 || destructuringErrors.DoubleProto >= 0;
+            return hasError;
         }
 
-        var hasShorthandAssign = destructuringErrors.ShorthandAssign >= 0;
-        var hasDoubleProto = destructuringErrors.DoubleProto >= 0;
-
-        if (hasShorthandAssign || hasDoubleProto)
+        if (hasError)
         {
-            if (hasShorthandAssign && (!hasDoubleProto || destructuringErrors.ShorthandAssign < destructuringErrors.DoubleProto))
-            {
-                // Raise(destructuringErrors.ShorthandAssign, "Shorthand property assignments are valid only in destructuring patterns"); // original acornjs error reporting
-                Raise(destructuringErrors.ShorthandAssign, InvalidCoverInitializedName);
-            }
-            else
-            {
-                // RaiseRecoverable(destructuringErrors.DoubleProto, "Redefinition of __proto__ property"); // original acornjs error reporting
-                Raise(destructuringErrors.DoubleProto, DuplicateProto);
-            }
+            // We deviate a bit from the original acornjs implementation here to match the error reporting behavior of V8.
+
+            //if (destructuringErrors.ShorthandAssign >= 0)
+            //{
+            //    Raise(destructuringErrors.ShorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+            //}
+
+            //if (destructuringErrors.DoubleProto >= 0)
+            //{
+            //    RaiseRecoverable(destructuringErrors.DoubleProto, "Redefinition of __proto__ property");
+            //}
+
+            ThrowExpressionError(destructuringErrors.ShorthandAssign, destructuringErrors.DoubleProto);
         }
 
         return false;
+    }
+
+    [DoesNotReturn]
+    private void ThrowExpressionError(int shorthandAssign, int doubleProto)
+    {
+        Debug.Assert(shorthandAssign >= 0 || doubleProto >= 0);
+
+        if (shorthandAssign >= 0 && (doubleProto < 0 || shorthandAssign < doubleProto))
+        {
+            Raise(shorthandAssign, InvalidCoverInitializedName);
+        }
+        else
+        {
+            Raise(doubleProto, DuplicateProto);
+        }
     }
 
     private void CheckAssignmentLhsErrors(Node convertedNode, ref DestructuringErrors destructuringErrors)
@@ -340,57 +359,71 @@ public partial class Parser
         // which, in the rare case of multiple ones (e.g. `[{a = 0}, {b = 0}.x] = []`), is not necessarily the position of the
         // one which remained unrefined. (V8 reports the position of the first one in such cases as well.)
 
-        var hasShorthandAssign = destructuringErrors.ShorthandAssign >= convertedNode.Start;
-        var hasDoubleProto = destructuringErrors.DoubleProto >= convertedNode.Start;
-
-        if (hasShorthandAssign || hasDoubleProto)
+        if (destructuringErrors.ShorthandAssign >= convertedNode.Start || destructuringErrors.DoubleProto >= convertedNode.Start)
         {
             // The recorded error(s) can only be discarded when the duplicate __proto__ and/or shorthand property assignment were
             // actually used correctly, that is, when the conversion refined the object literal containing them into an object pattern.
 
-            CheckForErrors(convertedNode, hasShorthandAssign, hasDoubleProto);
+            int shorthandAssign, doubleProto;
 
-            if (hasShorthandAssign)
+            if (destructuringErrors.ShorthandAssign >= convertedNode.Start)
             {
+                shorthandAssign = destructuringErrors.ShorthandAssign;
                 destructuringErrors.ShorthandAssign = -1;
             }
-
-            if (hasDoubleProto)
+            else
             {
+                shorthandAssign = -1;
+            }
+
+            if (destructuringErrors.DoubleProto >= convertedNode.Start)
+            {
+                doubleProto = destructuringErrors.DoubleProto;
                 destructuringErrors.DoubleProto = -1;
             }
+            else
+            {
+                doubleProto = -1;
+            }
+
+            CheckForErrors(convertedNode, shorthandAssign, doubleProto);
         }
 
-        void CheckForErrors(Node node, bool hasShorthandAssign, bool hasDoubleProto)
+        void CheckForErrors(Node node, int shorthandAssign, int doubleProto)
         {
+            _recursionDepth++;
+            StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
+
             var sawProto = false;
 
             foreach (var child in node.ChildNodes)
             {
                 if (child.Type == NodeType.Property && child is ObjectProperty property)
                 {
-                    if (hasShorthandAssign
+                    if (shorthandAssign >= 0
                         && property is { Shorthand: true, Value.Type: NodeType.AssignmentPattern })
                     {
-                        _tokenizer.RaiseAtNext(property.Value.As<AssignmentPattern>().Left.End, InvalidCoverInitializedName);
+                        ThrowExpressionError(shorthandAssign, doubleProto);
                     }
 
-                    if (hasDoubleProto
+                    if (doubleProto >= 0
                         // These conditions must be in sync with CheckPropertyClash.
                         && property is { Kind: PropertyKind.Init, Computed: false, Method: false, Shorthand: false }
                         && CheckKeyName(property.Key, computed: false, "__proto__"))
                     {
                         if (sawProto)
                         {
-                            Raise(property.Start, DuplicateProto);
+                            ThrowExpressionError(shorthandAssign, doubleProto);
                         }
 
                         sawProto = true;
                     }
                 }
 
-                CheckForErrors(child, hasShorthandAssign, hasDoubleProto);
+                CheckForErrors(child, shorthandAssign, doubleProto);
             }
+
+            _recursionDepth--;
         }
     }
 

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -657,7 +657,17 @@ public partial class Parser
 
                 var initPattern = ToAssignable(init, ref destructuringErrors, isBinding: false,
                     isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
+
+                // NOTE: The recorded shorthand property assignment error can only be discarded when the conversion refined
+                // the object literal containing it into an object pattern (see also ConsumeCoverInitializedNameError).
+                var coverInitializedNamePosition = ConsumeCoverInitializedNameError(ref destructuringErrors, initPattern);
+
                 CheckLValPattern(initPattern, isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
+
+                if (coverInitializedNamePosition >= 0)
+                {
+                    Raise(coverInitializedNamePosition, InvalidCoverInitializedName);
+                }
 
                 return ParseForInOf(startMarker, isForIn: true, await: false, initPattern);
             }
@@ -677,7 +687,17 @@ public partial class Parser
 
                 var initPattern = ToAssignable(init, ref destructuringErrors, isBinding: false,
                     isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
+
+                // NOTE: The recorded shorthand property assignment error can only be discarded when the conversion refined
+                // the object literal containing it into an object pattern (see also ConsumeCoverInitializedNameError).
+                var coverInitializedNamePosition = ConsumeCoverInitializedNameError(ref destructuringErrors, initPattern);
+
                 CheckLValPattern(initPattern, isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
+
+                if (coverInitializedNamePosition >= 0)
+                {
+                    Raise(coverInitializedNamePosition, InvalidCoverInitializedName);
+                }
 
                 return ParseForInOf(startMarker, isForIn: false, await: awaitAt >= 0, initPattern);
             }

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -658,16 +658,9 @@ public partial class Parser
                 var initPattern = ToAssignable(init, ref destructuringErrors, isBinding: false,
                     isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
 
-                // NOTE: The recorded shorthand property assignment error can only be discarded when the conversion refined
-                // the object literal containing it into an object pattern (see also ConsumeCoverInitializedNameError).
-                var coverInitializedNamePosition = ConsumeCoverInitializedNameError(ref destructuringErrors, initPattern);
-
                 CheckLValPattern(initPattern, isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
 
-                if (coverInitializedNamePosition >= 0)
-                {
-                    Raise(coverInitializedNamePosition, InvalidCoverInitializedName);
-                }
+                CheckAssignmentLhsErrors(initPattern, ref destructuringErrors);
 
                 return ParseForInOf(startMarker, isForIn: true, await: false, initPattern);
             }
@@ -688,16 +681,9 @@ public partial class Parser
                 var initPattern = ToAssignable(init, ref destructuringErrors, isBinding: false,
                     isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
 
-                // NOTE: The recorded shorthand property assignment error can only be discarded when the conversion refined
-                // the object literal containing it into an object pattern (see also ConsumeCoverInitializedNameError).
-                var coverInitializedNamePosition = ConsumeCoverInitializedNameError(ref destructuringErrors, initPattern);
-
                 CheckLValPattern(initPattern, isInPattern: destructuringErrors.IsInPattern, allowCall: !_strict, lhsKind: LeftHandSideKind.ForInOf);
 
-                if (coverInitializedNamePosition >= 0)
-                {
-                    Raise(coverInitializedNamePosition, InvalidCoverInitializedName);
-                }
+                CheckAssignmentLhsErrors(initPattern, ref destructuringErrors);
 
                 return ParseForInOf(startMarker, isForIn: false, await: awaitAt >= 0, initPattern);
             }
@@ -1826,8 +1812,8 @@ public partial class Parser
         // https://github.com/acornjs/acorn/blob/8.11.3/acorn/src/statement.js > `function checkKeyName`
 
         return !computed
-            && (key is Identifier identifier && identifier.Name == name
-                || key is StringLiteral literal && name.Equals(literal.Value));
+            && (key is Identifier identifier ? identifier.Name == name
+                : key is StringLiteral literal && literal.Value == name);
     }
 
     // Parses module export declaration.

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -652,6 +652,7 @@ public partial class Parser
             {
                 if (awaitAt >= 0) // this implies _ecmaVersion >= EcmaVersion.ES9
                 {
+                    // We deviate a bit from the original acornjs implementation here to match the error reporting behavior of V8.
                     CheckExpressionErrors(ref destructuringErrors, andThrow: true);
                     Unexpected(awaitAt, TokenType.Name, "await");
                 }
@@ -690,6 +691,7 @@ public partial class Parser
             }
             else
             {
+                // We deviate a bit from the original acornjs implementation here to match the error reporting behavior of V8.
                 CheckExpressionErrors(ref destructuringErrors, andThrow: true);
 
                 if (awaitAt >= 0)

--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -652,6 +652,7 @@ public partial class Parser
             {
                 if (awaitAt >= 0) // this implies _ecmaVersion >= EcmaVersion.ES9
                 {
+                    CheckExpressionErrors(ref destructuringErrors, andThrow: true);
                     Unexpected(awaitAt, TokenType.Name, "await");
                 }
 
@@ -687,12 +688,15 @@ public partial class Parser
 
                 return ParseForInOf(startMarker, isForIn: false, await: awaitAt >= 0, initPattern);
             }
-            else if (awaitAt >= 0)
+            else
             {
-                Unexpected();
-            }
+                CheckExpressionErrors(ref destructuringErrors, andThrow: true);
 
-            CheckExpressionErrors(ref destructuringErrors, andThrow: true);
+                if (awaitAt >= 0)
+                {
+                    Unexpected();
+                }
+            }
         }
 
         if (awaitAt >= 0)

--- a/src/Acornima/TokenType.cs
+++ b/src/Acornima/TokenType.cs
@@ -200,7 +200,7 @@ internal sealed partial class TokenType
 
     private static TokenType KeywordOperator(string label, KeywordEnum keyword, EcmaVersion ecmaVersion = EcmaVersion.ES3,
         bool beforeExpression = false, bool startsExpression = false, bool isLoop = false,
-        bool isAssignment = false, bool prefix = false, bool postfix = false, int precedence = -1)
+        bool isAssignment = false, bool prefix = false, int precedence = -1)
     {
         return new TokenType(label, TokenKind.Keyword,
             keyword: keyword,
@@ -211,7 +211,6 @@ internal sealed partial class TokenType
             isLoop: isLoop,
             isAssignment: isAssignment,
             prefix: prefix,
-            postfix: postfix,
             precedence: precedence);
     }
 

--- a/src/Acornima/Tokenizer.cs
+++ b/src/Acornima/Tokenizer.cs
@@ -1995,32 +1995,6 @@ public sealed partial class Tokenizer : ITokenizer
         return _options._errorHandler.TolerateError(error, _options._tolerant);
     }
 
-    internal void RaiseAtNext(int pos, string message, ParseError.Factory? errorFactory = null,
-        [CallerArgumentExpression(nameof(message))] string code = UnknownError)
-    {
-        var oldOnComment = _options._onComment;
-        var oldOnToken = _options._onToken;
-        var oldOnRegExp = _options._onRegExp;
-
-        _options._onComment = null;
-        _options._onToken = null;
-        _options._onRegExp = null;
-
-        try
-        {
-            ResetInternal(_input, pos, _endPosition - pos, _sourceType, _sourceFile);
-            NextToken();
-        }
-        finally
-        {
-            _options._onComment = oldOnComment;
-            _options._onToken = oldOnToken;
-            _options._onRegExp = oldOnRegExp;
-        }
-
-        Raise(_start, message, errorFactory, code);
-    }
-
     /// <summary>
     /// Checks whether an ECMAScript regular expression is syntactically correct.
     /// </summary>

--- a/src/Acornima/Tokenizer.cs
+++ b/src/Acornima/Tokenizer.cs
@@ -1995,6 +1995,32 @@ public sealed partial class Tokenizer : ITokenizer
         return _options._errorHandler.TolerateError(error, _options._tolerant);
     }
 
+    internal void RaiseAtNext(int pos, string message, ParseError.Factory? errorFactory = null,
+        [CallerArgumentExpression(nameof(message))] string code = UnknownError)
+    {
+        var oldOnComment = _options._onComment;
+        var oldOnToken = _options._onToken;
+        var oldOnRegExp = _options._onRegExp;
+
+        _options._onComment = null;
+        _options._onToken = null;
+        _options._onRegExp = null;
+
+        try
+        {
+            ResetInternal(_input, pos, _endPosition - pos, _sourceType, _sourceFile);
+            NextToken();
+        }
+        finally
+        {
+            _options._onComment = oldOnComment;
+            _options._onToken = oldOnToken;
+            _options._onRegExp = oldOnRegExp;
+        }
+
+        Raise(_start, message, errorFactory, code);
+    }
+
     /// <summary>
     /// Checks whether an ECMAScript regular expression is syntactically correct.
     /// </summary>

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -2729,6 +2729,130 @@ public partial class ParserTests
         }
     }
 
+    // https://github.com/adams85/acornima/issues/46
+    // A shorthand property assignment (CoverInitializedName, e.g. `{a = 0}`) is only allowed when the object literal
+    // containing it is refined into an object assignment pattern. (See also
+    // https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors, Note 2.)
+    [Theory]
+    // The object literal is not refined because the destructuring assignment target is the member expression which
+    // contains it - a valid assignment target on its own.
+    [InlineData("script", "({a = 0}.x = 0);", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a = 0}.x = 0);", "Invalid shorthand property initializer")]
+    [InlineData("script", "({a = 0}.x += 0);", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a = 0}.x += 0);", "Invalid shorthand property initializer")]
+    [InlineData("script", "({a = 0}.x ??= 0);", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a = 0}.x ??= 0);", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "[...{a = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[...{a = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "({a: {b = 0}.x} = {});", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a: {b = 0}.x} = {});", "Invalid shorthand property initializer")]
+    [InlineData("script", "({...{b = 0}.x} = {});", "Invalid shorthand property initializer")]
+    [InlineData("module", "({...{b = 0}.x} = {});", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}[0]] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}[0]] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}].x = 0;", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}].x = 0;", "Invalid shorthand property initializer")]
+    [InlineData("script", "[[{a = 0}.x]] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[[{a = 0}.x]] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "({a: [{b = 0}.x]} = {});", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a: [{b = 0}.x]} = {});", "Invalid shorthand property initializer")]
+    [InlineData("script", "([{a = 0}.x] = []);", "Invalid shorthand property initializer")]
+    [InlineData("module", "([{a = 0}.x] = []);", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}] = [{b = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}] = [{b = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}.x = 1] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}.x = 1] = [];", "Invalid shorthand property initializer")]
+
+    // Only some of the object literals are refined. (The reported position is that of the first shorthand property
+    // assignment, which may not be the one which remained unrefined - just like in the case of V8.)
+    [InlineData("script", "[{a = 0}, {b = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}, {b = 0}.x] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}.x, {b = 0}] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}.x, {b = 0}] = [];", "Invalid shorthand property initializer")]
+
+    // The head of a for-in/of statement is refined the same way as the left-hand side of an assignment.
+    [InlineData("script", "for ([{a = 0}.x] of []) ;", "Invalid shorthand property initializer")]
+    [InlineData("module", "for ([{a = 0}.x] of []) ;", "Invalid shorthand property initializer")]
+    [InlineData("script", "for ({a = 0}.x of []) ;", "Invalid shorthand property initializer")]
+    [InlineData("module", "for ({a = 0}.x of []) ;", "Invalid shorthand property initializer")]
+    [InlineData("script", "for ([{a = 0}.x] in {}) ;", "Invalid shorthand property initializer")]
+    [InlineData("module", "for ([{a = 0}.x] in {}) ;", "Invalid shorthand property initializer")]
+    [InlineData("script", "for ([{a = 0}.x] = [] ;;) ;", "Invalid shorthand property initializer")]
+    [InlineData("module", "for ([{a = 0}.x] = [] ;;) ;", "Invalid shorthand property initializer")]
+
+    // There is no assignment at all, so the object literal cannot be refined.
+    [InlineData("script", "({a = 0});", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a = 0});", "Invalid shorthand property initializer")]
+    [InlineData("script", "f({a = 0});", "Invalid shorthand property initializer")]
+    [InlineData("module", "f({a = 0});", "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}.x];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[{a = 0}.x];", "Invalid shorthand property initializer")]
+    [InlineData("script", "({a: {b = 0}.x});", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a: {b = 0}.x});", "Invalid shorthand property initializer")]
+    [InlineData("script", "({...{b = 0}.x});", "Invalid shorthand property initializer")]
+    [InlineData("module", "({...{b = 0}.x});", "Invalid shorthand property initializer")]
+    [InlineData("script", "[({a = 0})] = [];", "Invalid shorthand property initializer")]
+    [InlineData("module", "[({a = 0})] = [];", "Invalid shorthand property initializer")]
+    [InlineData("script", "({a = 0}) = {};", "Invalid shorthand property initializer")]
+    [InlineData("module", "({a = 0}) = {};", "Invalid shorthand property initializer")]
+    [InlineData("script", "f({a = 0}) = 0;", "Invalid shorthand property initializer")]
+    [InlineData("module", "f({a = 0}) = 0;", "Invalid shorthand property initializer")]
+
+    // The left-hand side is reported as invalid before the shorthand property assignment is.
+    [InlineData("script", "({a = 0} += 1);", "Invalid left-hand side in assignment")]
+    [InlineData("module", "({a = 0} += 1);", "Invalid left-hand side in assignment")]
+    [InlineData("script", "[{a = 0}.x] += 1;", "Invalid left-hand side in assignment")] // V8 reports "Invalid shorthand property initializer"
+    [InlineData("module", "[{a = 0}.x] += 1;", "Invalid left-hand side in assignment")] // V8 reports "Invalid shorthand property initializer"
+    [InlineData("script", "({a = 0}?.x = 0);", "Invalid left-hand side in assignment")]
+    [InlineData("module", "({a = 0}?.x = 0);", "Invalid left-hand side in assignment")]
+    [InlineData("script", "({a = 0}.x) => 0;", "Illegal property in declaration context")] // V8 reports "Invalid destructuring assignment target"
+    [InlineData("module", "({a = 0}.x) => 0;", "Illegal property in declaration context")] // V8 reports "Invalid destructuring assignment target"
+
+    // The object literal is refined, so the shorthand property assignment is legal.
+    [InlineData("script", "({a = 0} = {});", null)]
+    [InlineData("module", "({a = 0} = {});", null)]
+    [InlineData("script", "[{a = 0}] = [];", null)]
+    [InlineData("module", "[{a = 0}] = [];", null)]
+    [InlineData("script", "[{a = 0}, {b = 0}] = [];", null)]
+    [InlineData("module", "[{a = 0}, {b = 0}] = [];", null)]
+    [InlineData("script", "({a: {b = 0}} = {});", null)]
+    [InlineData("module", "({a: {b = 0}} = {});", null)]
+    [InlineData("script", "[{a = 0} = 1] = [];", null)]
+    [InlineData("module", "[{a = 0} = 1] = [];", null)]
+    [InlineData("script", "[...{a = 0}] = [];", null)]
+    [InlineData("module", "[...{a = 0}] = [];", null)]
+    [InlineData("script", "for ([{a = 0}] of []) ;", null)]
+    [InlineData("module", "for ([{a = 0}] of []) ;", null)]
+    [InlineData("script", "for ({a = 0} of [{}]) ;", null)]
+    [InlineData("module", "for ({a = 0} of [{}]) ;", null)]
+    [InlineData("script", "for ([{a = 0}] = [] ;;) ;", null)]
+    [InlineData("module", "for ([{a = 0}] = [] ;;) ;", null)]
+    [InlineData("script", "({a = 0}) => 0;", null)]
+    [InlineData("module", "({a = 0}) => 0;", null)]
+    [InlineData("script", "async ({a = 0}) => 0;", null)]
+    [InlineData("module", "async ({a = 0}) => 0;", null)]
+
+    // There is no shorthand property assignment at all.
+    [InlineData("script", "[{a: 0}.x] = [];", null)]
+    [InlineData("module", "[{a: 0}.x] = [];", null)]
+    public void ShouldHandleCoverInitializedNameEdgeCases(string sourceType, string input, string? expectedError)
+    {
+        var parser = new Parser();
+        var parseAction = GetParseActionFor(sourceType);
+
+        if (expectedError is null)
+        {
+            Assert.NotNull(parseAction(parser, input));
+        }
+        else
+        {
+            var ex = Assert.Throws<SyntaxErrorException>(() => parseAction(parser, input));
+            Assert.Equal(expectedError, ex.Description);
+        }
+    }
+
     [Theory]
     [InlineData("as")]
     [InlineData("do")]

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -1703,11 +1703,63 @@ public partial class ParserTests
     [InlineData("script", "[...x,]=a", EcmaVersion.Latest, "Rest element must be last element")]
     [InlineData("script", "{...x,}=a", EcmaVersion.Latest, "Unexpected token '...'")] // V8 reports "Rest parameter must be last formal parameter"
     [InlineData("script", "({...x,}=a)", EcmaVersion.Latest, "Rest element must be last element")]
-
+    [InlineData("script", "++{__proto__: x, __proto__: y}", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid left-hand side expression in prefix operation"
+    [InlineData("module", "++{__proto__: x, __proto__: y}", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid left-hand side expression in prefix operation"
     [InlineData("script", "({__proto__: x, __proto__: y}++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid left-hand side expression in postfix operation"
     [InlineData("module", "({__proto__: x, __proto__: y}++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid left-hand side expression in postfix operation"
     [InlineData("script", "({__proto__: x, __proto__: y}\n++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
     [InlineData("module", "({__proto__: x, __proto__: y}\n++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+
+    [InlineData("script", "({__proto__: x, __proto__: y}.x = 0)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "({__proto__: x, __proto__: y}.x += 0)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "++{__proto__: x, __proto__: y}.x", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "({__proto__: x, __proto__: y}.x++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "for ({__proto__: x, __proto__: y}.x = 0;;) { }", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "for ({__proto__: x, __proto__: y}.x in {}) { }", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "for ({__proto__: x, __proto__: y}.x of []) { }", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "async () => { for await ({__proto__: x, __proto__: y}.x of []) { } }", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+
+    [InlineData("script", "({__proto__: x, __proto__: y}[x] = 0)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "({__proto__: x, __proto__: y}() = 0)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "({__proto__: x, __proto__: y}`` = 0)", EcmaVersion.Latest, "Invalid left-hand side in assignment")]
+    [InlineData("script", "async () => { for await ({__proto__: x, __proto__: y}[x] of []) { } }", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "async () => { for await ({__proto__: x, __proto__: y}() of []) { } }", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 incorrectly accepts this! (Chrome 151)
+    [InlineData("script", "async () => { for await ({__proto__: x, __proto__: y}`` of []) { } }", EcmaVersion.Latest, "Invalid left-hand side in for-loop")]
+
+    [InlineData("script", "({ [{__proto__: x, __proto__: y}]: x } = 0)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "({ [{__proto__: x, __proto__: y} = 0]: x } = 0)", EcmaVersion.Latest, null)]
+
+    [InlineData("script", "({a = 0})", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}, {b = 0}.x]", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "f({a = 0})", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}.x]", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "({a: {b = 0}.x})", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "({...{b = 0}.x})", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+
+    [InlineData("script", "({a = 0}.x = 0)", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "({a = 0}.x += 0)", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "({a = 0}.x++)", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "(++{a = 0}.x)", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}][0] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[...{a = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "({a: {b = 0}.x} = {})", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "({...{b = 0}.x} = {})", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}[0]] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{a = 0}, {b = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "for ([{a = 0}.x];;) { }", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "for ([{a = 0}.x] in []) { }", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "for ([{a = 0}.x] of []) { }", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "async () => { for await ([{a = 0}.x] of []) { } }", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+
+    [InlineData("script", "[{a = 0}] = []", EcmaVersion.Latest, null)]
+    [InlineData("script", "({a: {b = 0}} = {})", EcmaVersion.Latest, null)]
+    [InlineData("script", "[{a: 0}.x] = []", EcmaVersion.Latest, null)]
+
+    [InlineData("script", "[{__proto__: a, __proto__: a, x = 0}, {__proto__: a, __proto__: a}.x] = []", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "[{__proto__: a, x = 0, __proto__: a}, {__proto__: a, __proto__: a}.x] = []", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid shorthand property initializer"
+    [InlineData("script", "[{__proto__: a, __proto__: a, x = 0}, {x = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]  // V8 reports "Duplicate __proto__ fields are not allowed in object literals"
+    [InlineData("script", "[{__proto__: a, x = 0, __proto__: a}, {x = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
     public void ShouldHandleVariableAssignmentEdgeCases(string sourceType, string input, EcmaVersion ecmaVersion, string? expectedError)
     {
         var parser = new Parser(new ParserOptions { EcmaVersion = ecmaVersion });

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -1553,8 +1553,8 @@ public partial class ParserTests
     [InlineData("module", "async function f() { ++{await} }", EcmaVersion.Latest, "Unexpected reserved word")]
     [InlineData("script", "async function f() { ++{x: await} }", EcmaVersion.Latest, "Unexpected token '}'")]
     [InlineData("module", "async function f() { ++{x: await} }", EcmaVersion.Latest, "Unexpected token '}'")]
-    [InlineData("script", "async function f() { ++{x = await} }", EcmaVersion.Latest, "Unexpected token '='")] // V8 reports "Unexpected token '}'"
-    [InlineData("module", "async function f() { ++{x = await} }", EcmaVersion.Latest, "Unexpected token '='")] // V8 reports "Unexpected token '}'"
+    [InlineData("script", "async function f() { ++{x = await} }", EcmaVersion.Latest, "Unexpected token '}'")]
+    [InlineData("module", "async function f() { ++{x = await} }", EcmaVersion.Latest, "Unexpected token '}'")]
     [InlineData("script", "async function f() { ++{...await} }", EcmaVersion.Latest, "Unexpected token '}'")]
     [InlineData("module", "async function f() { ++{...await} }", EcmaVersion.Latest, "Unexpected token '}'")]
 
@@ -1673,8 +1673,8 @@ public partial class ParserTests
     [InlineData("module", "function* g() { ++{yield} }", EcmaVersion.Latest, "Unexpected strict mode reserved word")]
     [InlineData("script", "function* g() { ++{x: yield} }", EcmaVersion.Latest, "Invalid left-hand side expression in prefix operation")]
     [InlineData("module", "function* g() { ++{x: yield} }", EcmaVersion.Latest, "Invalid left-hand side expression in prefix operation")]
-    [InlineData("script", "function* g() { ++{x = yield} }", EcmaVersion.Latest, "Unexpected token '='")] // V8 reports "Invalid left-hand side expression in prefix operation"
-    [InlineData("module", "function* g() { ++{x = yield} }", EcmaVersion.Latest, "Unexpected token '='")] // V8 reports "Invalid left-hand side expression in prefix operation"
+    [InlineData("script", "function* g() { ++{x = yield} }", EcmaVersion.Latest, "Invalid shorthand property initializer")] // V8 reports "Invalid left-hand side expression in prefix operation"
+    [InlineData("module", "function* g() { ++{x = yield} }", EcmaVersion.Latest, "Invalid shorthand property initializer")] // V8 reports "Invalid left-hand side expression in prefix operation"
     [InlineData("script", "function* g() { ++{...yield} }", EcmaVersion.Latest, "Invalid left-hand side expression in prefix operation")]
     [InlineData("module", "function* g() { ++{...yield} }", EcmaVersion.Latest, "Invalid left-hand side expression in prefix operation")]
 
@@ -1692,8 +1692,8 @@ public partial class ParserTests
     [InlineData("module", "function* g() { ({yield}++) }", EcmaVersion.Latest, "Unexpected strict mode reserved word")]
     [InlineData("script", "function* g() { ({x: yield}++) }", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
     [InlineData("module", "function* g() { ({x: yield}++) }", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
-    [InlineData("script", "function* g() { ({x = yield}++) }", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
-    [InlineData("module", "function* g() { ({x = yield}++) }", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
+    [InlineData("script", "function* g() { ({x = yield}++) }", EcmaVersion.Latest, "Invalid shorthand property initializer")] // V8 reports "Invalid left-hand side expression in postfix operation"
+    [InlineData("module", "function* g() { ({x = yield}++) }", EcmaVersion.Latest, "Invalid shorthand property initializer")] // V8 reports "Invalid left-hand side expression in postfix operation"
     [InlineData("script", "function* g() { ({x = yield}\n++) }", EcmaVersion.Latest, "Invalid shorthand property initializer")]
     [InlineData("module", "function* g() { ({x = yield}\n++) }", EcmaVersion.Latest, "Invalid shorthand property initializer")]
     [InlineData("script", "function* g() { ({...yield}++) }", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
@@ -1704,8 +1704,8 @@ public partial class ParserTests
     [InlineData("script", "{...x,}=a", EcmaVersion.Latest, "Unexpected token '...'")] // V8 reports "Rest parameter must be last formal parameter"
     [InlineData("script", "({...x,}=a)", EcmaVersion.Latest, "Rest element must be last element")]
 
-    [InlineData("script", "({__proto__: x, __proto__: y}++)", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
-    [InlineData("module", "({__proto__: x, __proto__: y}++)", EcmaVersion.Latest, "Invalid left-hand side expression in postfix operation")]
+    [InlineData("script", "({__proto__: x, __proto__: y}++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid left-hand side expression in postfix operation"
+    [InlineData("module", "({__proto__: x, __proto__: y}++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid left-hand side expression in postfix operation"
     [InlineData("script", "({__proto__: x, __proto__: y}\n++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
     [InlineData("module", "({__proto__: x, __proto__: y}\n++)", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
     public void ShouldHandleVariableAssignmentEdgeCases(string sourceType, string input, EcmaVersion ecmaVersion, string? expectedError)

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -1756,10 +1756,13 @@ public partial class ParserTests
     [InlineData("script", "({a: {b = 0}} = {})", EcmaVersion.Latest, null)]
     [InlineData("script", "[{a: 0}.x] = []", EcmaVersion.Latest, null)]
 
+    [InlineData("script", "[{__proto__: a, __proto__: a}, {x = 0}.x] = []", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
+    [InlineData("script", "[{x = 0}, {__proto__: a, __proto__: a}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
     [InlineData("script", "[{__proto__: a, __proto__: a, x = 0}, {__proto__: a, __proto__: a}.x] = []", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
-    [InlineData("script", "[{__proto__: a, x = 0, __proto__: a}, {__proto__: a, __proto__: a}.x] = []", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")] // V8 reports "Invalid shorthand property initializer"
-    [InlineData("script", "[{__proto__: a, __proto__: a, x = 0}, {x = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]  // V8 reports "Duplicate __proto__ fields are not allowed in object literals"
+    [InlineData("script", "[{__proto__: a, x = 0, __proto__: a}, {__proto__: a, __proto__: a}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[{__proto__: a, __proto__: a, x = 0}, {x = 0}.x] = []", EcmaVersion.Latest, "Duplicate __proto__ fields are not allowed in object literals")]
     [InlineData("script", "[{__proto__: a, x = 0, __proto__: a}, {x = 0}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
+    [InlineData("script", "[[{a = 0}], {b = 0} = {}, {c: [{__proto__: a, __proto__: a}]}.x] = []", EcmaVersion.Latest, "Invalid shorthand property initializer")]
     public void ShouldHandleVariableAssignmentEdgeCases(string sourceType, string input, EcmaVersion ecmaVersion, string? expectedError)
     {
         var parser = new Parser(new ParserOptions { EcmaVersion = ecmaVersion });


### PR DESCRIPTION
Fixes #46.

`{ a = 0 }` is only legal as a *cover* for an `ObjectAssignmentPattern`. When the enclosing left-hand side is refined into an assignment pattern the literal becomes a pattern and the shorthand-with-initializer is fine; when it is **not** refined — because it is the object of a member expression, which is already a valid assignment target on its own — the literal stays an `ObjectLiteral` and §13.2.5.1's early error must fire. All nine forms in the issue parsed clean, where V8 rejects every one.

### Root cause

`ReinterpretAssignmentTarget` discarded the pending `ShorthandAssign` error whenever its position fell inside the converted left-hand side — **a position test standing in for a refinement test**. `ToAssignable` deliberately stops at a `MemberExpression` (it is already a valid `DestructuringAssignmentTarget`) and never descends into its object, so in `[{a = 0}.x] = []` the literal stays an `ObjectExpression` while the pending error is dropped anyway.

The **for-in/of heads** have the same hole for a different reason: they never consult the pending error at all, so it is silently discarded when `destructuringErrors` goes out of scope.

### Why the reset line could not simply be deleted

I built that variant to check, and it is worth recording because it is the obvious first attempt: deleting the reset **breaks legal code** — `({a = 0} = {});` and `({a: {b = 0}} = {});`, ordinary destructuring-with-defaults, start throwing — and it *still* misses five of the nine forms, because the `=` branch of `ParseMaybeAssign` returns without ever calling `CheckExpressionErrors`, so an un-reset error is never reported, and the for-in/of heads are separate sites.

So the fix has to decide refinement from the **converted node** rather than from a position, raise the error explicitly, and cover the for-in/of heads. `ConsumeCoverInitializedNameError` does the first two; the decision procedure rests on an invariant worth stating plainly:

> In an `ObjectExpression`, a shorthand property whose value is an `AssignmentPattern` can only have come from a CoverInitializedName — a refined literal is an `ObjectPattern` whose members are `AssignmentProperty` nodes.

So "was it refined?" is answered by searching the converted node for such a node.

The error is raised **after** `CheckLValPattern`/`CheckLValSimple`, so an invalid left-hand side still reports first — which preserves the existing `({x = yield} += 1)` → *Invalid left-hand side in assignment* pin, and matches what V8 does in most of these cases.

### Cost

Nothing is added to per-node work. `ConsumeCoverInitializedNameError` opens with the same `ShorthandAssign < node.Start` comparison the old reset used and returns immediately when nothing is pending, so the common path pays one compare-and-branch per assignment expression and per expression-headed for-in/of. `ContainsCoverInitializedName` runs only when a CoverInitializedName was actually recorded inside the converted node — i.e. either an about-to-be-reported error, or a destructuring assignment genuinely using shorthand defaults — and is then bounded by that left-hand side's size. It is iterative with an explicit `ArrayList<Node>` stack, so it adds no depth to the parser's stack-guarded recursion.

Measured on the repo's own eight benchmark files (best-of-15, 5×8 parses, alternating pre/post processes): pre median 413.7 ms, post median 399.6 ms — the post median is *lower*, which the change cannot cause, so the effect is below run-to-run noise. An 800-deep nested array pattern resolves correctly both ways; depth 1600 raises `InsufficientExecutionStackException` on both builds, which is the pre-existing `StackGuard`.

### Verification

New theory `ShouldHandleCoverInitializedNameEdgeCases`, 88 rows (44 sources × script/module): the issue's 9 + 5 + 3 matrix plus 27 further forms — mixed refined/unrefined in both orders, nested arrays and objects, `for-in`, plain `for`-init, `??=`, sequence, chained assignment, parenthesized, and arrow-parameter controls. Written first and run against the unfixed parser: **40 failed, 48 passed**, every failure `Assert.Throws() Failure: No exception was thrown` — the predicted mode.

After: 88/88. Full suite `13098` (net10.0) / `13095` (net9.0, net8.0, net462); test262 **99090** passing, 0 failed; source generators 2/2; and the Debug configuration run too, since the new `Debug.Assert` only exists there.

Differential against V8 (node 24.19.0) over **684 generated forms** — 36 shapes × 19 syntactic contexts:

| build | mismatches vs V8 |
| --- | --- |
| before | **165** / 684 |
| after | **0** / 684 |

Every one of the 165 behaviour changes is `accept → reject`; nothing that already agreed with V8 moved.

### Two things deliberately left alone

**The reported position** stays Acornima's own — the `=` token of the shorthand property, where V8 points at the key — and in the mixed case (`[{a = 0}, {b = 0}.x] = []`) it is the *first* recorded shorthand assign, which is not necessarily the one that stayed unrefined. V8 reports the first one there too. Making it exact would mean recording every position rather than the first, growing `DestructuringErrors`.

**Two pre-existing ordering divergences from V8 are preserved rather than "fixed"**: `[{a = 0}.x] += 1` and `({a = 0} += 1)` report *Invalid left-hand side in assignment* where V8 reports the shorthand error, and `({a = 0}.x) => 0` reports *Illegal property in declaration context*. Changing them would contradict the existing `ShouldHandleVariableAssignmentEdgeCases` pins. All three carry `// V8 reports "…"` comments in the new theory.

Note the issue's finding that **acorn 8.18.0 shares this defect**, so this is not a port of an upstream fix — happy to adjust the approach if you would rather it track acorn.

Found while working on [Jint](https://github.com/sebastienros/jint); it is one of the two parser gaps blocking test262 `staging/` there (sebastienros/jint#3021). I hand-checked `staging/sm/destructuring/bug1396261.js`: all 10 must-parse statements parse and all 4 must-throw sources now throw. Acornima's own `Test262Harness.settings.json` does not include `staging` in `SubDirectories`, which is why the suite stayed green on this — adding those ~2,800 cases felt like a separate change with its own triage rather than something to fold in here.
