### PR TITLE
Fix legacy octal constructs being rejected right after a strict function body

### DIFF
--- a/src/Acornima/Parser.Statement.cs
+++ b/src/Acornima/Parser.Statement.cs
@@ -1093,13 +1093,17 @@ public partial class Parser
             EnterScope(ScopeFlags.None);
         }
 
-        while (!Eat(TokenType.BraceRight))
+        while (_tokenizer._type != TokenType.BraceRight)
         {
             var statement = ParseStatement(StatementContext.Default);
             body.Add(statement);
         }
 
+        // NOTE: Strict mode must be exited before the closing brace is consumed because consuming it also reads the token
+        // which follows the block, and that token already belongs to the enclosing code, which may well be non-strict.
+        // (This is why the consumption of the closing brace is not folded into the loop condition, unlike elsewhere.)
         _strict = _strict && !exitStrict;
+        Next();
 
         return createNewLexicalScope ? ExitScope() : default;
     }

--- a/test/Acornima.Tests/ParserTests.cs
+++ b/test/Acornima.Tests/ParserTests.cs
@@ -727,6 +727,45 @@ public partial class ParserTests
         Assert.True(q.Body.Strict);
     }
 
+    [Fact]
+    public void CodeFollowingStrictFunctionShouldNotBeStrict()
+    {
+        // The legacy octal literal is valid as it's not part of the strict function's code,
+        // not even when it immediately follows the closing brace of the function body.
+        // See https://github.com/adams85/acornima/issues/50
+
+        var parser = new Parser();
+        var program = parser.ParseScript("function p() {'use strict'; } 0755");
+
+        var p = program.Body.First().As<FunctionDeclaration>();
+        Assert.True(p.Body.Strict);
+
+        var literal = program.Body.Skip(1).First().As<ExpressionStatement>().Expression.As<NumericLiteral>();
+        Assert.Equal(493d, literal.Value); // 0755
+
+        Assert.False(program.Strict);
+    }
+
+    [Theory]
+    // In tolerant mode no error may be recorded for the token which follows the closing brace of a strict function body
+    // when the enclosing code is not strict, and exactly one must be recorded when it is.
+    // See https://github.com/adams85/acornima/issues/50
+    [InlineData("function f() { 'use strict' } 0755", false, 0)]
+    [InlineData("function f() { 'use strict'; } '\\222'", false, 0)]
+    [InlineData("function f() { 'use strict' } 0755\nfunction g() { 'use strict' } 0644", false, 0)]
+    [InlineData("function f() { 'use strict'; 0755 }", false, 1)]
+    [InlineData("'use strict'; function f() {} 0755", false, 1)]
+    [InlineData("function f() { 'use strict'; function g() {} 0755 }", false, 1)]
+    [InlineData("function f() { 'use strict' } 0755", true, 1)]
+    public void ShouldReportLegacyOctalFollowingStrictFunctionBodyOnlyInStrictCode(string input, bool strict, int expectedErrorCount)
+    {
+        var errorCollector = new ParseErrorCollector();
+        var parser = new Parser(new ParserOptions { Tolerant = true, ErrorHandler = errorCollector });
+        parser.ParseScript(input, strict: strict);
+
+        Assert.Equal(expectedErrorCount, errorCollector.Errors.Count);
+    }
+
     [Theory]
     [InlineData("'use strict'; 0", false, EcmaVersion.ES3, null)]
     [InlineData("'use strict'; 0", false, EcmaVersion.ES5, null)]
@@ -781,6 +820,43 @@ public partial class ParserTests
     [InlineData("(x = 0) => {'use strict'; 0 }; 00", false, EcmaVersion.ES6, null)]
     [InlineData("'use strict'; (x = 0) => {'use strict'; 0 }; 00", false, EcmaVersion.ES6, "Octal literals are not allowed in strict mode")]
     [InlineData("(x = 0) => {'use strict'; 0 }; 00", true, EcmaVersion.ES6, "Octal literals are not allowed in strict mode")]
+
+    // Strict mode must be turned off before the token which follows the closing brace of a strict function body is read,
+    // as that token already belongs to the enclosing code. See https://github.com/adams85/acornima/issues/50
+    [InlineData("function f() { 'use strict' } 0755", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict'; } 0755", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict' } 00", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict'; } 08", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict'; } 09", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict'; } '\\222'", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict'; } '\\8'", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict'; } '\\9'", false, EcmaVersion.ES5, null)]
+    [InlineData("function f() { 'use strict' } 0755", false, EcmaVersion.ES3, null)]
+    [InlineData("x = function() { 'use strict' }\n0755", false, EcmaVersion.ES5, null)]
+    [InlineData("async function f() { 'use strict' } 0755", false, EcmaVersion.ES8, null)]
+    [InlineData("function* g() { 'use strict' } 0755", false, EcmaVersion.ES6, null)]
+    [InlineData("async function* g() { 'use strict' } 0755", false, EcmaVersion.ES9, null)]
+    [InlineData("x = () => { 'use strict' }\n0755", false, EcmaVersion.ES6, null)]
+    [InlineData("x = () => { 'use strict' }\n'\\222'", false, EcmaVersion.ES6, null)]
+    [InlineData("x = async () => { 'use strict' }\n0755", false, EcmaVersion.ES8, null)]
+    [InlineData("({ m() { 'use strict' }, n: 0755 })", false, EcmaVersion.ES6, null)]
+    [InlineData("({ get m() { 'use strict' }, n: 0755 })", false, EcmaVersion.ES6, null)]
+    [InlineData("({ set m(v) { 'use strict' }, n: 0755 })", false, EcmaVersion.ES6, null)]
+    [InlineData("class C { m() { 'use strict' } } 0755", false, EcmaVersion.ES6, null)]
+
+    // ...but only when the enclosing code isn't strict for a reason of its own, in which case strict mode must be kept.
+    [InlineData("'use strict'; function f() {} 0755", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("'use strict'; function f() { 'use strict' } 0755", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict' } 0755", true, EcmaVersion.ES6, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; function g() {} 0755 }", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; function g() { 'use strict' } 0755 }", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; function g() { 'use strict'; } '\\222' }", false, EcmaVersion.ES5, "Octal escape sequences are not allowed in strict mode")]
+    [InlineData("'use strict'; { } 0755", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; { } 0755 }", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; if (x) { } 0755 }", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; try { } finally { } 0755 }", false, EcmaVersion.ES5, "Octal literals are not allowed in strict mode")]
+    [InlineData("function f() { 'use strict'; with (x) {} } 0755", false, EcmaVersion.ES5, "Strict mode code may not include a with statement")]
+    [InlineData("class C { static { 0755 } }", false, EcmaVersion.ES13, "Octal literals are not allowed in strict mode")]
 
     [InlineData("'use strict';\r\nfunction f(arguments){}", false, EcmaVersion.ES3, null)]
     [InlineData("'use strict';\r\nfunction f(arguments){}", false, EcmaVersion.ES5, "Unexpected eval or arguments in strict mode")]


### PR DESCRIPTION
Fixes #50.

`ParseBlock` consumed the block's closing brace inside its loop condition (`while (!Eat(TokenType.BraceRight))`), and `Eat` calls `Next()`. `Parser.Next()` passes the *current* `_strict` into `TokenizerContext`, and `Tokenizer.Next` assigns `_strict = _inModule || context.Strict` **before** `NextToken()` scans — so the token that call reads is checked against the strictness in force at the call site. With the `_strict = _strict && !exitStrict` restore sitting *after* the loop, the first token of the enclosing code was scanned in the function body's strict mode, and the four legacy-octal checks in `Tokenizer` — the only four places it reads `_strict` — rejected valid sloppy code.

The issue's suggested shape survived verbatim, and it is doubly corroborated: it is acorn's ordering (`acorn/src/statement.js:542-543` — `if (exitStrict) this.strict = false` then `this.next()`), and **it is already the shape `ParseClass` uses in this same file**, which is exactly why `class C {} 0755` was never affected.

I audited the other five `while (!Eat(TokenType.BraceRight))` sites — `ParseSwitchStatement`, `ParseClassStaticBlock`, `ParseExportSpecifiers`, `ParseImportSpecifiers`, `ParseImportAttributes` — and none touches `_strict`. The complete set of `_strict` writes is init / `ParseBlock` / `ParseClass` / the prologue. `ParseBlock` was the only defective site.

### Why `_strict && !exitStrict` rather than `_strict = false`

The existing expression is kept deliberately, and the reason is broader than the nested-function case. `exitStrict` is computed by the caller as `strict && !oldStrict`, so for `function f() { "use strict"; function g() { "use strict" } 0755 }` the inner body sees `exitStrict == false`, the restore is a no-op, and `0755` is still rejected — verified unchanged.

But **`ParseBlock` parses every block**, not only function bodies: `{ }`, `if`/`while`/`try` bodies, all with `exitStrict: false`. An unconditional `_strict = false` would make `'use strict'; { } 0755` and `function f() { 'use strict'; try { } finally { } 0755 }` parse. Both are now pinned as must-throw.

### Matrix

98 rows, cross-checked against V8 24.19.0 and acorn 8.16.0. **19 rows flip ERR → OK; every other row is byte-identical before and after** — error code, message, index, line and column.

Flipping: the three from the issue, plus all four legacy-octal kinds (`\8`, `\9`, `08`, `09`, `08.5`, `00`), function expressions and arrows via ASI, `async function`, `function*`, `async function*`, `async () =>`.

Deliberately *not* flipping, and each explains itself: `(function(){ "use strict" })\n0755` and object methods / getters / setters were already fine — a `)` or a `,` absorbs the one bad token, which is itself proof the defect was exactly one token wide. Class forms were already fine because `ParseClass` had the right ordering. Nested strict functions, blocks inside strict code, outer `'use strict'`, modules and the `strict: true` option all keep rejecting.

The only 8 differences against V8/acorn are fully explained: two are ES-version gating (V8 is always latest, so it rejects the ES3 and ES6 rows Acornima's gates accept — both already pinned by existing tests) and six are tolerant-mode rows, where neither has an equivalent mode.

### Relationship to #49

**No existing test encoded the buggy behaviour** — proven rather than assumed: the full suite is green with the fix and needed no edits. I also re-read all 45 rows and 3 theories #49 adds; none places a legacy octal after a strict body's closing brace.

I went further and tested the combination: cherry-picked #49 onto this commit. **No conflict in either shared file** (`Parser.Statement.cs`, `ParserTests.cs` — my rows are anchored next to the existing `(x = 0) => {…}; 00` group, away from #49's insertion points). With both applied: build clean, 13,125 unit tests green, test262 99,090/99,090, and the 98-row matrix produced output **identical to this fix alone**. Then reset back, tree hash verified unchanged.

**Either order works; no sequencing needed.** The two are orthogonal — #49 records legacy octals in sloppy mode for retroactive reporting and is consulted only inside `ParseDirectivePrologue`, which never runs on the token after a function's `}`.

### Verification

Written first and run against the **unfixed** parser: **19 failed, 76 passed**. Every stack trace was the predicted mechanism (`ReadNumber → RaiseRecoverable(StrictOctalLiteral)` ← `Tokenizer.Next` ← `ParseBlock` line 1096, the `Eat()` in the loop condition). All 12 must-throw rows and all 55 pre-existing rows passed unfixed, so the fix had to move exactly those 19 and nothing else. After: 95/95.

Full suite, Release: solution builds with **0 warnings** under `TreatWarningsAsErrors` across all 9 TFM outputs; `Acornima.Tests` 13,047 (net8.0/net9.0/net462) and 13,050 (net10.0); **test262 99,090/99,090**; source generators 2/2. Also run in Debug with identical counts.

### Performance — cheaper, measured at machine-code level

Not asserted. `DOTNET_JitDisasm=ParseBlock` with `DOTNET_TieredCompilation=0` (FullOpts, .NET 10 x64), both builds:

- **before**, per loop iteration: `mov rcx,[tokenizer]` / `mov rdx,[_type]` / `mov r8,<static addr>` / `cmp rdx,[r8]` / `jne` — **4 instructions plus the branch**, with the `TokenType.BraceRight` static reload inside the loop.
- **after**, per loop iteration: `mov rdx,[tokenizer]` / `cmp [_type], r14` / `jne` — **2 instructions plus the branch**. With the condition no longer wrapping an inlined call, the JIT hoists the `BraceRight` read into `r14` in the pre-header, and hoists `ArrayList.PushRef`'s type handle into `r15` as well.

So the restructure is not neutral, it is cheaper per statement parsed. The cost is a 15-byte larger method (445 → 460) and a one-time pre-header cost per `ParseBlock` call, not per iteration.

No BenchmarkDotNet figures — an effect this size is below what `Acornima.Benchmarks` can resolve and the disassembly is the stronger evidence, but happy to run one if you would like a number for the record.

### Diff

`Parser.Statement.cs` (+6/−1): the loop condition becomes `while (_tokenizer._type != TokenType.BraceRight)`, the existing restore is followed by an explicit `Next()`, and a three-line `// NOTE:` records *why* the closing brace is deliberately not consumed by the loop condition here — so a future tidy-up does not re-fold it.

`ParserTests.cs` (+76): 32 rows on `ShouldHandleStrictModeDetectionEdgeCases` (20 must-parse, 12 must-throw), one `Fact` asserting the body is still `Strict` *and* the following `0755` parses as 493 *and* the program is not strict, and one `Theory` pinning tolerant-mode error **counts** — the axis the non-tolerant theory cannot reach, since a recoverable error would otherwise be recorded silently.

I left the other five `!Eat(TokenType.BraceRight)` loops alone: none touches `_strict`, so changing them would be an unrelated perf tweak inside a bug-fix PR.

Found while working on [Jint](https://github.com/sebastienros/jint).
